### PR TITLE
Rewrite "MA Channel" indicator

### DIFF
--- a/mql40/include/rsf/api.mqh
+++ b/mql40/include/rsf/api.mqh
@@ -344,7 +344,7 @@ double   icDonchianChannel(int timeframe, int periods, int iBuffer, int iBar);;
 double   icHalfTrend(int timeframe, int periods, int iBuffer, int iBar);;
 double   icJMA(int timeframe, int periods, int phase, string appliedPrice, int iBuffer, int iBar);;
 double   icMACD(int timeframe, string fastMaMethod, int fastMaPeriods, string fastMaAppliedPrice, string slowMaMethod, int slowMaPeriods, string slowMaAppliedPrice, string unit, int adrPeriods, int iBuffer, int iBar);;
-double   icMaChannel(int timeframe, int ma1Method, int ma1ChannelWidth, int ma1Periods, int ma2Method, int ma2ChannelWidth, int ma2Periods, int ma3Method, int ma3ChannelWidth, int ma3Periods, int iBuffer, int iBar);;
+double   icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma1ChannelWidth, int ma2Method, int ma2Periods, int ma2ChannelWidth, int ma3Method, int ma3Periods, int ma3ChannelWidth, int iBuffer, int iBar);;
 double   icMovingAverage(int timeframe, string maMethod, int maPeriods, string maAppliedPrice, int iBuffer, int iBar);;
 double   icZigZag(int timeframe, int periods, int iBuffer, int iBar);;
 

--- a/mql40/include/rsf/api.mqh
+++ b/mql40/include/rsf/api.mqh
@@ -344,7 +344,7 @@ double   icDonchianChannel(int timeframe, int periods, int iBuffer, int iBar);;
 double   icHalfTrend(int timeframe, int periods, int iBuffer, int iBar);;
 double   icJMA(int timeframe, int periods, int phase, string appliedPrice, int iBuffer, int iBar);;
 double   icMACD(int timeframe, string fastMaMethod, int fastMaPeriods, string fastMaAppliedPrice, string slowMaMethod, int slowMaPeriods, string slowMaAppliedPrice, string unit, int adrPeriods, int iBuffer, int iBar);;
-double   icMaChannel(int timeframe, string channelDefinition, int iBuffer, int iBar);;
+double   icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma2Method, int ma2Periods, int ma3Method, int ma3Periods, int iBuffer, int iBar);;
 double   icMovingAverage(int timeframe, string maMethod, int maPeriods, string maAppliedPrice, int iBuffer, int iBar);;
 double   icZigZag(int timeframe, int periods, int iBuffer, int iBar);;
 

--- a/mql40/include/rsf/api.mqh
+++ b/mql40/include/rsf/api.mqh
@@ -344,7 +344,7 @@ double   icDonchianChannel(int timeframe, int periods, int iBuffer, int iBar);;
 double   icHalfTrend(int timeframe, int periods, int iBuffer, int iBar);;
 double   icJMA(int timeframe, int periods, int phase, string appliedPrice, int iBuffer, int iBar);;
 double   icMACD(int timeframe, string fastMaMethod, int fastMaPeriods, string fastMaAppliedPrice, string slowMaMethod, int slowMaPeriods, string slowMaAppliedPrice, string unit, int adrPeriods, int iBuffer, int iBar);;
-double   icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma2Method, int ma2Periods, int ma3Method, int ma3Periods, int iBuffer, int iBar);;
+double   icMaChannel(int timeframe, int ma1Method, int ma1ChannelWidth, int ma1Periods, int ma2Method, int ma2ChannelWidth, int ma2Periods, int ma3Method, int ma3ChannelWidth, int ma3Periods, int iBuffer, int iBar);;
 double   icMovingAverage(int timeframe, string maMethod, int maPeriods, string maAppliedPrice, int iBuffer, int iBar);;
 double   icZigZag(int timeframe, int periods, int iBuffer, int iBar);;
 

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -11,21 +11,24 @@
 /**
  * Load the "MA Channel" indicator and return a value.
  *
- * @param  int timeframe  - timeframe to load the indicator (NULL: the current timeframe)
+ * @param  int timeframe       - timeframe to load the indicator (NULL: the current timeframe)
  *
- * @param  int ma1Method  - indicator parameter
- * @param  int ma1Periods - indicator parameter
- * @param  int ma2Method  - indicator parameter
- * @param  int ma2Periods - indicator parameter
- * @param  int ma3Method  - indicator parameter
- * @param  int ma3Periods - indicator parameter
+ * @param  int ma1Method       - indicator parameter
+ * @param  int ma1Periods      - indicator parameter
+ * @param  int ma1ChannelWidth - indicator parameter
+ * @param  int ma2Method       - indicator parameter
+ * @param  int ma2Periods      - indicator parameter
+ * @param  int ma2ChannelWidth - indicator parameter
+ * @param  int ma3Method       - indicator parameter
+ * @param  int ma3Periods      - indicator parameter
+ * @param  int ma3ChannelWidth - indicator parameter
  *
- * @param  int iBuffer    - indicator buffer index of the value to return
- * @param  int iBar       - bar index of the value to return
+ * @param  int iBuffer         - indicator buffer index of the value to return
+ * @param  int iBar            - bar index of the value to return
  *
  * @return double - indicator value or NULL in case of errors
  */
-double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma2Method, int ma2Periods, int ma3Method, int ma3Periods, int iBuffer, int iBar) {
+double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma1ChannelWidth, int ma2Method, int ma2Periods, int ma2ChannelWidth, int ma3Method, int ma3Periods, int ma3ChannelWidth, int iBuffer, int iBar) {
    static int lpSuperContext = 0; if (!lpSuperContext) {
       lpSuperContext = GetIntsAddress(__ExecutionContext);
    }
@@ -37,14 +40,17 @@ double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma2Method, 
                           "",                         // string _______________________
                           sMa1Method,                 // string MA1.Method
                           ma1Periods,                 // int    MA1.Periods
+                          ma1ChannelWidth,            // int    MA1.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA1.Color
 
                           sMa1Method,                 // string MA2.Method
                           ma2Periods,                 // int    MA2.Periods
+                          ma2ChannelWidth,            // int    MA2.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA2.Color
 
                           sMa1Method,                 // string MA3.Method
                           ma3Periods,                 // int    MA3.Periods
+                          ma3ChannelWidth,            // int    MA3.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA3.Color
 
                           "",                         // string _______________________

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -1,4 +1,3 @@
-
 #define MaChannel.MODE_MA1_UPPER_BAND  0              // indicator buffer ids
 #define MaChannel.MODE_MA1_LOWER_BAND  1              //
 #define MaChannel.MODE_MA2_UPPER_BAND  2              //
@@ -10,30 +9,40 @@
 /**
  * Load the "MA Channel" indicator and return a value.
  *
- * @param  int    timeframe         - timeframe to load the indicator (NULL: the current timeframe)
- * @param  string channelDefinition - indicator parameter
- * @param  int    iBuffer           - indicator buffer index of the value to return
- * @param  int    iBar              - bar index of the value to return
+ * @param  int timeframe  - timeframe to load the indicator (NULL: the current timeframe)
+ *
+ * @param  int ma1Method  - indicator parameter
+ * @param  int ma1Periods - indicator parameter
+ * @param  int ma2Method  - indicator parameter
+ * @param  int ma2Periods - indicator parameter
+ * @param  int ma3Method  - indicator parameter
+ * @param  int ma3Periods - indicator parameter
+ *
+ * @param  int iBuffer    - indicator buffer index of the value to return
+ * @param  int iBar       - bar index of the value to return
  *
  * @return double - indicator value or NULL in case of errors
  */
-double icMaChannel(int timeframe, string channelDefinition, int iBuffer, int iBar) {
+double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma2Method, int ma2Periods, int ma3Method, int ma3Periods, int iBuffer, int iBar) {
    static int lpSuperContext = 0; if (!lpSuperContext) {
       lpSuperContext = GetIntsAddress(__ExecutionContext);
    }
+   string sMa1Method = ma1Method;                     // we can't implicitly cast iCustom() arguments
+   string sMa2Method = ma2Method;
+   string sMa3Method = ma3Method;
 
    double value = iCustom(NULL, timeframe, "MA Channel",
                           "",                         // string _______________________
-                          "",                         // string MA1.Method
-                          0,                          // int    MA1.Periods
+                          sMa1Method,                 // string MA1.Method
+                          ma1Periods,                 // int    MA1.Periods
                           CLR_NONE,                   // color  MA1.Color
 
-                          "",                         // string MA2.Method
-                          0,                          // int    MA2.Periods
+                          sMa1Method,                 // string MA2.Method
+                          ma2Periods,                 // int    MA2.Periods
                           CLR_NONE,                   // color  MA2.Color
 
-                          "",                         // string MA3.Method
-                          0,                          // int    MA3.Periods
+                          sMa1Method,                 // string MA3.Method
+                          ma3Periods,                 // int    MA3.Periods
                           CLR_NONE,                   // color  MA3.Color
 
                           "",                         // string _______________________

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -4,6 +4,8 @@
 #define MaChannel.MODE_MA2_LOWER_BAND  3              //
 #define MaChannel.MODE_MA3_UPPER_BAND  4              //
 #define MaChannel.MODE_MA3_LOWER_BAND  5              //
+#define MaChannel.MODE_POSITION        6              // overall price position (all MA channels): -1..0..+1
+#define MaChannel.MODE_TREND           7              // overall channel trend (all MA channels):  -n..0..+n
 
 
 /**

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -58,10 +58,16 @@ double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma1ChannelW
                           -1,                         // int    MaxBarsBack
 
                           "",                         // string _______________________
-                          false,                      // bool   Signal.onBarCross
-                          "",                         // string Signal.onBarCross.Types
-                          "",                         // string Signal.Sound.Up
-                          "",                         // string Signal.Sound.Down
+                          false,                      // bool   Signal.onPositionChange
+                          "",                         // string Signal.onPosition.Types
+                          "",                         // string Signal.onPosition.Sound.Above
+                          "",                         // string Signal.onPosition.Sound.Below
+                          "",                         // string Signal.onPosition.Sound.Between
+
+                          false,                      // bool   Signal.onTrendChange
+                          "",                         // string Signal.onTrend.Types
+                          "",                         // string Signal.onTrend.Sound.Up
+                          "",                         // string Signal.onTrend.Sound.Down
 
                           "",                         // string _______________________
                           false,                      // bool   AutoConfiguration

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -43,12 +43,12 @@ double icMaChannel(int timeframe, int ma1Method, int ma1Periods, int ma1ChannelW
                           ma1ChannelWidth,            // int    MA1.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA1.Color
 
-                          sMa1Method,                 // string MA2.Method
+                          sMa2Method,                 // string MA2.Method
                           ma2Periods,                 // int    MA2.Periods
                           ma2ChannelWidth,            // int    MA2.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA2.Color
 
-                          sMa1Method,                 // string MA3.Method
+                          sMa3Method,                 // string MA3.Method
                           ma3Periods,                 // int    MA3.Periods
                           ma3ChannelWidth,            // int    MA3.ChannelWidth.Pct
                           CLR_NONE,                   // color  MA3.Color

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -1,6 +1,10 @@
-#define MaChannel.MODE_UPPER_BAND   0                 // indicator buffer ids
-#define MaChannel.MODE_LOWER_BAND   1                 //
-#define MaChannel.MODE_TREND        2                 //
+
+#define MaChannel.MODE_MA1_UPPER_BAND  0              // indicator buffer ids
+#define MaChannel.MODE_MA1_LOWER_BAND  1              //
+#define MaChannel.MODE_MA2_UPPER_BAND  2              //
+#define MaChannel.MODE_MA2_LOWER_BAND  3              //
+#define MaChannel.MODE_MA3_UPPER_BAND  4              //
+#define MaChannel.MODE_MA3_LOWER_BAND  5              //
 
 
 /**
@@ -19,8 +23,18 @@ double icMaChannel(int timeframe, string channelDefinition, int iBuffer, int iBa
    }
 
    double value = iCustom(NULL, timeframe, "MA Channel",
-                          channelDefinition,          // string Channel.Definition
-                          Blue,                       // color  Channel.Color
+                          "",                         // string _______________________
+                          "",                         // string MA1.Method
+                          0,                          // int    MA1.Periods
+                          CLR_NONE,                   // color  MA1.Color
+
+                          "",                         // string MA2.Method
+                          0,                          // int    MA2.Periods
+                          CLR_NONE,                   // color  MA2.Color
+
+                          "",                         // string MA3.Method
+                          0,                          // int    MA3.Periods
+                          CLR_NONE,                   // color  MA3.Color
 
                           "",                         // string _______________________
                           false,                      // bool   ShowChartLegend

--- a/mql40/include/rsf/functions/iCustom/MaChannel.mqh
+++ b/mql40/include/rsf/functions/iCustom/MaChannel.mqh
@@ -21,7 +21,6 @@ double icMaChannel(int timeframe, string channelDefinition, int iBuffer, int iBa
    double value = iCustom(NULL, timeframe, "MA Channel",
                           channelDefinition,          // string Channel.Definition
                           Blue,                       // color  Channel.Color
-                          "",                         // string Supported.MovingAverages
 
                           "",                         // string _______________________
                           false,                      // bool   ShowChartLegend

--- a/mql40/include/rsf/stdfunctions.mqh
+++ b/mql40/include/rsf/stdfunctions.mqh
@@ -2431,9 +2431,9 @@ int StrToLogLevel(string value, int flags = NULL) {
 
 
 /**
- * Return the integer constant of a "Moving Average" method representation.
+ * Return the integer constant of a "Moving Average" method.
  *
- * @param  string value            - string representation of a "Moving Average" method
+ * @param  string value            - string describing a "Moving Average" method
  * @param  int    flags [optional] - execution control flags (default: none)
  *                                   F_PARTIAL_ID:            recognize partial but unique identifiers, e.g. "AL" = "ALMA"
  *                                   F_ERR_INVALID_PARAMETER: don't trigger a fatal error on unrecognized values

--- a/mql40/indicators/ChartInfos.mq4
+++ b/mql40/indicators/ChartInfos.mq4
@@ -541,8 +541,6 @@ int ShowOpenOrders(int customTickets[], int flags = NULL) {
             ObjectSet(label1, OBJPROP_COLOR,     colors[OP_SELL]);
             ObjectSet(label1, OBJPROP_TIME1,     openTime);
             ObjectSet(label1, OBJPROP_PRICE1,    openPrice);
-
-            logInfo("ShowOpenOrders(2)  negative TB reversals "+ key +": "+ value);
             displayedOrders++;
          }
          if (displayedOrders > 0) {

--- a/mql40/indicators/MA Channel Band.mq4
+++ b/mql40/indicators/MA Channel Band.mq4
@@ -333,10 +333,10 @@ bool onTrendChange(int direction) {
  */
 double GetMaChannel(int mode, int bar) {
    if (channel.method == MODE_ALMA) {
-      static int buffers[] = {0, MaChannel.MODE_UPPER_BAND, MaChannel.MODE_LOWER_BAND};
-      return(icMaChannel(NULL, channel.definition, buffers[mode], bar));
+      static int buffers[] = { 0, MaChannel.MODE_MA1_UPPER_BAND, MaChannel.MODE_MA1_LOWER_BAND };
+      return(icMaChannel(NULL, MODE_ALMA, channel.periods, 0, 0, 0, 0, buffers[mode], bar));
    }
-   static int prices[] = {0, PRICE_HIGH, PRICE_LOW};
+   static int prices[] = { 0, PRICE_HIGH, PRICE_LOW };
    return(iMA(NULL, NULL, channel.periods, 0, channel.method, prices[mode], bar));
 }
 

--- a/mql40/indicators/MA Channel Band.mq4
+++ b/mql40/indicators/MA Channel Band.mq4
@@ -334,7 +334,7 @@ bool onTrendChange(int direction) {
 double GetMaChannel(int mode, int bar) {
    if (channel.method == MODE_ALMA) {
       static int buffers[] = { 0, MaChannel.MODE_MA1_UPPER_BAND, MaChannel.MODE_MA1_LOWER_BAND };
-      return(icMaChannel(NULL, MODE_ALMA, channel.periods, 0, 0, 0, 0, buffers[mode], bar));
+      return(icMaChannel(NULL, MODE_ALMA, channel.periods, 100, 0, 0, 0, 0, 0, 0, buffers[mode], bar));
    }
    static int prices[] = { 0, PRICE_HIGH, PRICE_LOW };
    return(iMA(NULL, NULL, channel.periods, 0, channel.method, prices[mode], bar));

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -57,8 +57,8 @@ double trend    [];                                      // trend direction: inv
 #define MA_METHOD    0                                   // indexes of ma[]
 #define MA_PERIODS   1
 
-string maDefinitions[];                                  // MA definitions
-int    ma[][2];                                          // integer representation
+string sMaDefinitions[];                                 // MA definitions (human-readable)
+int    iMaDefinitions[][2];                              // MA definitions (numeric)
 int    maxMaPeriods;
 
 string indicatorName = "";
@@ -84,9 +84,9 @@ int onInit() {
    string indicator = WindowExpertName();
 
    // Channel.Definition
-   ArrayResize(ma, 0);
-   ArrayResize(maDefinitions, 0);
-   int mas = 0;
+   ArrayResize(iMaDefinitions, 0);
+   ArrayResize(sMaDefinitions, 0);
+   int sizeMas = 0;
    maxMaPeriods = 0;
 
    string sValues[], sValue = Channel.Definition;
@@ -109,16 +109,16 @@ int onInit() {
       int iPeriods = StrToInteger(sPeriods);
       if (iPeriods < 1)                return(catch("onInit(6)  invalid MA periods "+ iPeriods +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (must be positive)", ERR_INVALID_INPUT_PARAMETER));
 
-      ArrayResize(ma, mas+1);
-      ArrayResize(maDefinitions, mas+1);
-      ma[mas][MA_METHOD ] = iMethod;
-      ma[mas][MA_PERIODS] = iPeriods;
-      maDefinitions[mas]  = MaMethodDescription(iMethod) +"("+ iPeriods +")";
+      ArrayResize(iMaDefinitions, sizeMas+1);
+      ArrayResize(sMaDefinitions, sizeMas+1);
+      iMaDefinitions[sizeMas][MA_METHOD ] = iMethod;
+      iMaDefinitions[sizeMas][MA_PERIODS] = iPeriods;
+      sMaDefinitions[sizeMas] = MaMethodDescription(iMethod) +"("+ iPeriods +")";
       maxMaPeriods = MathMax(maxMaPeriods, iPeriods);
-      mas++;
+      sizeMas++;
    }
-   if (!mas)                           return(catch("onInit(7)  missing input parameter Channel.Definition", ERR_INVALID_INPUT_PARAMETER));
-   Channel.Definition = JoinStrings(maDefinitions, ",");
+   if (!sizeMas)                       return(catch("onInit(7)  missing input parameter Channel.Definition", ERR_INVALID_INPUT_PARAMETER));
+   Channel.Definition = JoinStrings(sMaDefinitions, ",");
 
    // Channel.Color: after deserialization the terminal may turn CLR_NONE (0xFFFFFFFF) into Black (0xFF000000)
    if (AutoConfiguration) Channel.Color = GetConfigColor(indicator, "Channel.Color", Channel.Color);
@@ -178,15 +178,15 @@ int onTick() {
    int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods), prevTrend;
    if (startbar < 0 && MaxBarsBack) return(logInfo("onTick(1)  Tick="+ Ticks, ERR_HISTORY_INSUFFICIENT));
 
-   int numberOfMas = ArrayRange(ma, 0);
+   int sizeMas = ArrayRange(iMaDefinitions, 0);
 
    // recalculate changed bars
    for (int bar=startbar; bar >= 0; bar--) {
       double high = INT_MIN, low = INT_MAX;
 
-      for (int i=0; i < numberOfMas; i++) {
-         high = MathMax(high, iMA(NULL, NULL, ma[i][MA_PERIODS], 0, ma[i][MA_METHOD], PRICE_HIGH, bar));
-         low  = MathMin(low,  iMA(NULL, NULL, ma[i][MA_PERIODS], 0, ma[i][MA_METHOD], PRICE_LOW,  bar));
+      for (int i=0; i < sizeMas; i++) {
+         high = MathMax(high, iMA(NULL, NULL, iMaDefinitions[i][MA_PERIODS], 0, iMaDefinitions[i][MA_METHOD], PRICE_HIGH, bar));
+         low  = MathMin(low,  iMA(NULL, NULL, iMaDefinitions[i][MA_PERIODS], 0, iMaDefinitions[i][MA_METHOD], PRICE_LOW,  bar));
       }
       upperBand[bar] = high;
       lowerBand[bar] = low;
@@ -300,7 +300,7 @@ bool onCross(int direction) {
  */
 bool SetIndicatorOptions(bool redraw = false) {
    redraw = redraw!=0;
-   indicatorName = ifString(ArraySize(maDefinitions)==1, Channel.Definition +" Channel", WindowExpertName() +" "+ Channel.Definition);
+   indicatorName = GetChannelDescription();
    IndicatorShortName(indicatorName);
 
    IndicatorBuffers(indicator_buffers);
@@ -319,6 +319,44 @@ bool SetIndicatorOptions(bool redraw = false) {
 
    if (redraw) WindowRedraw();
    return(!catch("SetIndicatorOptions(1)"));
+}
+
+
+/**
+ * Generate a channel description for the chart legend.
+ *
+ * @return string
+ */
+string GetChannelDescription() {
+   string sMethod = "", sameMethods = "", differentMethods = "";
+   bool allSameMethod = true;
+   int size = ArrayRange(iMaDefinitions, 0), method, periods;
+
+   if (size == 1) {
+      sameMethods = sMaDefinitions[0] +" Channel";
+   }
+   else {
+      for (int i=0; i < size; i++) {
+         method  = iMaDefinitions[i][MA_METHOD];
+         periods = iMaDefinitions[i][MA_PERIODS];
+         sMethod = MaMethodDescription(method);
+
+         if (i && allSameMethod) {
+            allSameMethod = (method == iMaDefinitions[i-1][MA_METHOD]);
+         }
+         if (allSameMethod) {
+            if (i == 0) sameMethods = sMethod +"("+ periods;
+            else        sameMethods = sameMethods +","+ periods;
+         }
+         differentMethods = StringConcatenate(differentMethods, ",", sMethod, "(", periods, ")");
+      }
+      sameMethods      = sameMethods +") Channel";
+      differentMethods = StrRight(differentMethods, -1) +" Channel";
+   }
+
+   if (allSameMethod)
+      return(sameMethods);
+   return(differentMethods);
 }
 
 

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -7,8 +7,6 @@
  *
  * Input parameters
  * ----------------
- *  • ...
- *  • ...
  *
  *
  * Supported Moving Average methods
@@ -42,37 +40,37 @@ int __DeinitFlags[];
 
 ////////////////////////////////////////////////////// Configuration ////////////////////////////////////////////////////////
 
-extern string ___a__________________________  = "=== MA definitions ===";
-extern string MA1.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA1.Periods                     = 100;
-extern int    MA1.ChannelWidth.Pct            = 100;                     // percent of High/Low range
-extern color  MA1.Color                       = Magenta;
+extern string ___a__________________________ = "=== MA definitions ===";
+extern string MA1.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA1.Periods                    = 100;
+extern int    MA1.ChannelWidth.Pct           = 100;                     // percent of High/Low range
+extern color  MA1.Color                      = Magenta;
 
-extern string MA2.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA2.Periods                     = 0;
-extern int    MA2.ChannelWidth.Pct            = 100;
-extern color  MA2.Color                       = Blue;
+extern string MA2.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA2.Periods                    = 0;
+extern int    MA2.ChannelWidth.Pct           = 100;
+extern color  MA2.Color                      = Blue;
 
-extern string MA3.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA3.Periods                     = 0;
-extern int    MA3.ChannelWidth.Pct            = 100;
-extern color  MA3.Color                       = Red;
+extern string MA3.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA3.Periods                    = 0;
+extern int    MA3.ChannelWidth.Pct           = 100;
+extern color  MA3.Color                      = Red;
 
-extern string ___b__________________________  = "=== Display options ===";
-extern bool   ShowChartLegend                 = true;
-extern int    MaxBarsBack                     = 10000;                   // max. values to calculate (-1: all available)
+extern string ___b__________________________ = "=== Display options ===";
+extern bool   ShowChartLegend                = true;
+extern int    MaxBarsBack                    = 10000;                   // max. values to calculate (-1: all available)
 
-extern string ___c__________________________  = "=== Signaling ===";
-extern bool   Signal.onPositionChange         = false;                   // on BarClose crossing the position boundary
-extern string Signal.onPosition.Types         = "sound* | alert | mail | telegram";
-extern string Signal.onPosition.Sound.Above   = "Signal Up.wav";
-extern string Signal.onPosition.Sound.Below   = "Signal Down.wav";
-extern string Signal.onPosition.Sound.Between = "Signal Between.wav";
+extern string ___c__________________________ = "=== Signaling ===";
+extern bool   Signal.onPositionChange        = false;                   // on BarClose crossing the position boundary
+extern string Signal.onPosition.Types        = "sound* | alert | mail | telegram";
+extern string Signal.onPosition.Sound.Above  = "Signal Up.wav";
+extern string Signal.onPosition.Sound.Inside = "Signal Inside.wav";
+extern string Signal.onPosition.Sound.Below  = "Signal Down.wav";
 
-extern bool   Signal.onTrendChange            = false;                   // on BarClose causing a trend change
-extern string Signal.onTrend.Types            = "sound* | alert | mail | telegram";
-extern string Signal.onTrend.Sound.Up         = "Signal Up.wav";
-extern string Signal.onTrend.Sound.Down       = "Signal Down.wav";
+extern bool   Signal.onTrendChange           = false;                   // on BarClose causing a trend change
+extern string Signal.onTrend.Types           = "sound* | alert | mail | telegram";
+extern string Signal.onTrend.Sound.Up        = "Signal Up.wav";
+extern string Signal.onTrend.Sound.Down      = "Signal Down.wav";
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -299,9 +297,9 @@ int onInit() {
    }
 
    // sounds
-   if (AutoConfiguration) Signal.onPosition.Sound.Above   = GetConfigString(indicator, "Signal.onPosition.Sound.Above",   Signal.onPosition.Sound.Above);
-   if (AutoConfiguration) Signal.onPosition.Sound.Below   = GetConfigString(indicator, "Signal.onPosition.Sound.Below",   Signal.onPosition.Sound.Below);
-   if (AutoConfiguration) Signal.onPosition.Sound.Between = GetConfigString(indicator, "Signal.onPosition.Sound.Between", Signal.onPosition.Sound.Between);
+   if (AutoConfiguration) Signal.onPosition.Sound.Above  = GetConfigString(indicator, "Signal.onPosition.Sound.Above",  Signal.onPosition.Sound.Above);
+   if (AutoConfiguration) Signal.onPosition.Sound.Inside = GetConfigString(indicator, "Signal.onPosition.Sound.Inside", Signal.onPosition.Sound.Inside);
+   if (AutoConfiguration) Signal.onPosition.Sound.Below  = GetConfigString(indicator, "Signal.onPosition.Sound.Below",  Signal.onPosition.Sound.Below);
 
    if (AutoConfiguration) Signal.onTrend.Sound.Up   = GetConfigString(indicator, "Signal.onTrend.Sound.Up",   Signal.onTrend.Sound.Up);
    if (AutoConfiguration) Signal.onTrend.Sound.Down = GetConfigString(indicator, "Signal.onTrend.Sound.Down", Signal.onTrend.Sound.Down);
@@ -538,7 +536,7 @@ bool onPositionChange(int position) {
    if (!Signal.onPositionChange) return(false);
    if (ChangedBars > 2)          return(false);
 
-   static string sPositions[] = { "below", "in", "above" };
+   static string sPositions[] = { "below", "inside", "above" };
 
    // skip the signal if it was already handled elsewhere
    string sPeriod   = PeriodDescription();
@@ -572,7 +570,7 @@ bool onPositionChange(int position) {
       if (eventAction) {
          if      (position > 0) PlaySoundEx(Signal.onPosition.Sound.Above);
          else if (position < 0) PlaySoundEx(Signal.onPosition.Sound.Below);
-         else                   PlaySoundEx(Signal.onPosition.Sound.Between);
+         else                   PlaySoundEx(Signal.onPosition.Sound.Inside);
       }
    }
 
@@ -867,34 +865,34 @@ string GetChannelDescription() {
  */
 string InputsToStr() {
    return(StringConcatenate(
-      "MA1.Method=",                      DoubleQuoteStr(MA1.Method)                      +";"+ NL,
-      "MA1.Periods=",                     MA1.Periods                                     +";"+ NL,
-      "MA1.ChannelWidth.Pct=",            MA1.ChannelWidth.Pct                            +";"+ NL,
-      "MA1.Color=",                       ColorToStr(MA1.Color)                           +";"+ NL,
+      "MA1.Method=",                     DoubleQuoteStr(MA1.Method)                     +";"+ NL,
+      "MA1.Periods=",                    MA1.Periods                                    +";"+ NL,
+      "MA1.ChannelWidth.Pct=",           MA1.ChannelWidth.Pct                           +";"+ NL,
+      "MA1.Color=",                      ColorToStr(MA1.Color)                          +";"+ NL,
 
-      "MA2.Method=",                      DoubleQuoteStr(MA2.Method)                      +";"+ NL,
-      "MA2.Periods=",                     MA2.Periods                                     +";"+ NL,
-      "MA2.ChannelWidth.Pct=",            MA2.ChannelWidth.Pct                            +";"+ NL,
-      "MA2.Color=",                       ColorToStr(MA2.Color)                           +";"+ NL,
+      "MA2.Method=",                     DoubleQuoteStr(MA2.Method)                     +";"+ NL,
+      "MA2.Periods=",                    MA2.Periods                                    +";"+ NL,
+      "MA2.ChannelWidth.Pct=",           MA2.ChannelWidth.Pct                           +";"+ NL,
+      "MA2.Color=",                      ColorToStr(MA2.Color)                          +";"+ NL,
 
-      "MA3.Method=",                      DoubleQuoteStr(MA3.Method)                      +";"+ NL,
-      "MA3.Periods=",                     MA3.Periods                                     +";"+ NL,
-      "MA3.ChannelWidth.Pct=",            MA3.ChannelWidth.Pct                            +";"+ NL,
-      "MA3.Color=",                       ColorToStr(MA3.Color)                           +";"+ NL,
+      "MA3.Method=",                     DoubleQuoteStr(MA3.Method)                     +";"+ NL,
+      "MA3.Periods=",                    MA3.Periods                                    +";"+ NL,
+      "MA3.ChannelWidth.Pct=",           MA3.ChannelWidth.Pct                           +";"+ NL,
+      "MA3.Color=",                      ColorToStr(MA3.Color)                          +";"+ NL,
 
-      "ShowChartLegend=",                 BoolToStr(ShowChartLegend)                      +";"+ NL,
-      "MaxBarsBack=",                     MaxBarsBack                                     +";"+ NL,
+      "ShowChartLegend=",                BoolToStr(ShowChartLegend)                     +";"+ NL,
+      "MaxBarsBack=",                    MaxBarsBack                                    +";"+ NL,
 
-      "Signal.onPositionChange=",         BoolToStr(Signal.onPositionChange)              +";"+ NL,
-      "Signal.onPosition.Types=",         DoubleQuoteStr(Signal.onPosition.Types)         +";"+ NL,
-      "Signal.onPosition.Sound.Above=",   DoubleQuoteStr(Signal.onPosition.Sound.Above)   +";"+ NL,
-      "Signal.onPosition.Sound.Below=",   DoubleQuoteStr(Signal.onPosition.Sound.Below)   +";"+ NL,
-      "Signal.onPosition.Sound.Between=", DoubleQuoteStr(Signal.onPosition.Sound.Between) +";"+ NL,
+      "Signal.onPositionChange=",        BoolToStr(Signal.onPositionChange)             +";"+ NL,
+      "Signal.onPosition.Types=",        DoubleQuoteStr(Signal.onPosition.Types)        +";"+ NL,
+      "Signal.onPosition.Sound.Above=",  DoubleQuoteStr(Signal.onPosition.Sound.Above)  +";"+ NL,
+      "Signal.onPosition.Sound.Inside=", DoubleQuoteStr(Signal.onPosition.Sound.Inside) +";"+ NL,
+      "Signal.onPosition.Sound.Below=",  DoubleQuoteStr(Signal.onPosition.Sound.Below)  +";"+ NL,
 
-      "Signal.onTrendChange=",            BoolToStr(Signal.onTrendChange)                 +";"+ NL,
-      "Signal.onTrend.Types=",            DoubleQuoteStr(Signal.onTrend.Types)            +";"+ NL,
-      "Signal.onTrend.Sound..Up=",        DoubleQuoteStr(Signal.onTrend.Sound.Up)         +";"+ NL,
-      "Signal.onTrend.Sound..Down=",      DoubleQuoteStr(Signal.onTrend.Sound.Down)       +";"+ NL
+      "Signal.onTrendChange=",           BoolToStr(Signal.onTrendChange)                +";"+ NL,
+      "Signal.onTrend.Types=",           DoubleQuoteStr(Signal.onTrend.Types)           +";"+ NL,
+      "Signal.onTrend.Sound..Up=",       DoubleQuoteStr(Signal.onTrend.Sound.Up)        +";"+ NL,
+      "Signal.onTrend.Sound..Down=",     DoubleQuoteStr(Signal.onTrend.Sound.Down)      +";"+ NL
    ));
 
    // suppress compiler warnings

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -1,7 +1,8 @@
 /**
  * MA Channel
  *
- * An indicator forming a High/Low channel built from one or more Moving Averages.
+ * An indicator forming a High/Low channel around a Moving Average. A single instance can display up to 3 channels
+ * from multiple MAs. Supported MA types: SMA, LWMA, EMA, SMMA, ALMA.
  *
  *
  * TODO:
@@ -15,7 +16,6 @@ int __DeinitFlags[];
 
 extern string Channel.Definition             = "EMA(144)";              // one or more MAs, e.g "EMA(144), LWMA(55)"
 extern color  Channel.Color                  = Magenta;
-extern string Supported.MovingAverages       = "SMA, LWMA, EMA, SMMA";
 
 extern string ___a__________________________ = "=== Display options ===";
 extern bool   ShowChartLegend                = true;

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -11,9 +11,30 @@
  *  • ...
  *
  *
+ * Supported Moving Average methods
+ * --------------------------------
+ *  • SMA  = Simple Moving Average:          equal bar weighting
+ *  • LWMA = Linear Weighted Moving Average: bar weighting using a linear function
+ *  • EMA  = Exponential Moving Average:     bar weighting using an exponential function
+ *  • SMMA = Smoothed Moving Average:        bar weighting using an exponential function (an EMA, see notes)
+ *  • ALMA = Arnaud Legoux Moving Average:   bar weighting using a Gaussian function
+ *
+ *
  * Usage with iCustom()
  * --------------------
  * @see /mql40/include/rsf/functions/iCustom/MaChannel.mqh
+ *
+ *
+ * Notes
+ * -----
+ *  • EMA calculation:
+ *    @see https://web.archive.org/web/20221120050520/https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+ *
+ *  • SMMA calculation: The SMMA is an EMA with a different period. It holds true: SMMA(n) = EMA(2*n-1)
+ *    @see https://web.archive.org/web/20221120050520/https://en.wikipedia.org/wiki/Moving_average#Modified_moving_average
+ *
+ *  • ALMA calculation:
+ *    @see http://web.archive.org/web/20180307031850/http://www.arnaudlegoux.com/
  *
  *
  * TODO:
@@ -58,14 +79,15 @@ extern string Signal.Sound.Down              = "Signal Down.wav";
 #include <rsf/functions/IsBarOpen.mqh>
 #include <rsf/functions/ObjectCreateRegister.mqh>
 #include <rsf/functions/iCustom/MaChannel.mqh>
+#include <rsf/functions/ta/ALMA.mqh>
 #include <rsf/win32api.mqh>
 
-#define MODE_MA1_UPPER_BAND   MaChannel.MODE_MA1_UPPER_BAND    // 0 indicator buffer ids
-#define MODE_MA1_LOWER_BAND   MaChannel.MODE_MA1_LOWER_BAND    // 1
-#define MODE_MA2_UPPER_BAND   MaChannel.MODE_MA2_UPPER_BAND    // 2
-#define MODE_MA2_LOWER_BAND   MaChannel.MODE_MA2_LOWER_BAND    // 3
-#define MODE_MA3_UPPER_BAND   MaChannel.MODE_MA3_UPPER_BAND    // 4
-#define MODE_MA3_LOWER_BAND   MaChannel.MODE_MA3_LOWER_BAND    // 5
+#define MODE_MA1_UPPER  MaChannel.MODE_MA1_UPPER_BAND    // 0 indicator buffer ids
+#define MODE_MA1_LOWER  MaChannel.MODE_MA1_LOWER_BAND    // 1
+#define MODE_MA2_UPPER  MaChannel.MODE_MA2_UPPER_BAND    // 2
+#define MODE_MA2_LOWER  MaChannel.MODE_MA2_LOWER_BAND    // 3
+#define MODE_MA3_UPPER  MaChannel.MODE_MA3_UPPER_BAND    // 4
+#define MODE_MA3_LOWER  MaChannel.MODE_MA3_LOWER_BAND    // 5
 
 #property indicator_chart_window
 #property indicator_buffers   6                          // visible buffers
@@ -78,16 +100,19 @@ int    ma1.method;                                       // MA definition
 int    ma1.periods;                                      //
 double ma1.upperBand[];                                  // indicator buffers
 double ma1.lowerBand[];                                  //
+double ma1.almaWeights[];                                // ALMA bar weights (if applicable
 
 int    ma2.method;
 int    ma2.periods;
 double ma2.upperBand[];
 double ma2.lowerBand[];
+double ma2.almaWeights[];
 
 int    ma3.method;
 int    ma3.periods;
 double ma3.upperBand[];
 double ma3.lowerBand[];
+double ma3.almaWeights[];
 
 int    maxMaPeriods;
 
@@ -205,6 +230,12 @@ int onInit() {
    if (AutoConfiguration) Signal.Sound.Up   = GetConfigString(indicator, "Signal.Sound.Up",   Signal.Sound.Up);
    if (AutoConfiguration) Signal.Sound.Down = GetConfigString(indicator, "Signal.Sound.Down", Signal.Sound.Down);
 
+   // calculate ALMA bar weights
+   double almaOffset=0.85, almaSigma=6.0;
+   if (ma1.method == MODE_ALMA) ALMA.CalculateWeights(ma1.periods, almaOffset, almaSigma, ma1.almaWeights);
+   if (ma2.method == MODE_ALMA) ALMA.CalculateWeights(ma2.periods, almaOffset, almaSigma, ma2.almaWeights);
+   if (ma3.method == MODE_ALMA) ALMA.CalculateWeights(ma3.periods, almaOffset, almaSigma, ma3.almaWeights);
+
    // chart legend
    if (ShowChartLegend) legendLabel = CreateChartLegend();
 
@@ -245,18 +276,50 @@ int onTick() {
    if (startbar < 0 && MaxBarsBack) return(logInfo("onTick(1)  Tick="+ Ticks, ERR_HISTORY_INSUFFICIENT));
 
    // recalculate changed bars
-   for (int bar=startbar; bar >= 0; bar--) {
+   for (int bar=startbar, i; bar >= 0; bar--) {
       if (ma1.periods > 0) {
-         ma1.upperBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_HIGH, bar);
-         ma1.lowerBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_LOW,  bar);
+         if (ma1.method == MODE_ALMA) {
+            ma1.upperBand[bar] = 0;
+            ma1.lowerBand[bar] = 0;
+            for (i=0; i < ma1.periods; i++) {
+               ma1.upperBand[bar] += ma1.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
+               ma1.lowerBand[bar] += ma1.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+            }
+         }
+         else {
+            ma1.upperBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_HIGH, bar);
+            ma1.lowerBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_LOW,  bar);
+         }
       }
+
       if (ma2.periods > 0) {
-         ma2.upperBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_HIGH, bar);
-         ma2.lowerBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_LOW,  bar);
+         if (ma2.method == MODE_ALMA) {
+            ma2.upperBand[bar] = 0;
+            ma2.lowerBand[bar] = 0;
+            for (i=0; i < ma2.periods; i++) {
+               ma2.upperBand[bar] += ma2.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
+               ma2.lowerBand[bar] += ma2.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+            }
+         }
+         else {
+            ma2.upperBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_HIGH, bar);
+            ma2.lowerBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_LOW,  bar);
+         }
       }
+
       if (ma3.periods > 0) {
-         ma3.upperBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_HIGH, bar);
-         ma3.lowerBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_LOW,  bar);
+         if (ma3.method == MODE_ALMA) {
+            ma3.upperBand[bar] = 0;
+            ma3.lowerBand[bar] = 0;
+            for (i=0; i < ma3.periods; i++) {
+               ma3.upperBand[bar] += ma3.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
+               ma3.lowerBand[bar] += ma3.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+            }
+         }
+         else {
+            ma3.upperBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_HIGH, bar);
+            ma3.lowerBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_LOW,  bar);
+         }
       }
    }
 
@@ -369,44 +432,44 @@ bool SetIndicatorOptions(bool redraw = false) {
    IndicatorBuffers(indicator_buffers);
    IndicatorDigits(Digits);
 
-   SetIndexBuffer(MODE_MA1_UPPER_BAND, ma1.upperBand);
-   SetIndexBuffer(MODE_MA1_LOWER_BAND, ma1.lowerBand);
-   SetIndexStyle (MODE_MA1_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
-   SetIndexStyle (MODE_MA1_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
-   SetIndexLabel (MODE_MA1_UPPER_BAND, MA1.Method +"("+ MA1.Periods +") upper band");
-   SetIndexLabel (MODE_MA1_LOWER_BAND, MA1.Method +"("+ MA1.Periods +") lower band");
+   SetIndexBuffer(MODE_MA1_UPPER, ma1.upperBand);
+   SetIndexBuffer(MODE_MA1_LOWER, ma1.lowerBand);
+   SetIndexStyle (MODE_MA1_UPPER, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
+   SetIndexStyle (MODE_MA1_LOWER, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
+   SetIndexLabel (MODE_MA1_UPPER, MA1.Method +"("+ MA1.Periods +") upper band");
+   SetIndexLabel (MODE_MA1_LOWER, MA1.Method +"("+ MA1.Periods +") lower band");
 
-   SetIndexBuffer(MODE_MA2_UPPER_BAND, ma2.upperBand);
-   SetIndexBuffer(MODE_MA2_LOWER_BAND, ma2.lowerBand);
-   SetIndexStyle (MODE_MA2_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
-   SetIndexStyle (MODE_MA2_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
-   SetIndexLabel (MODE_MA2_UPPER_BAND, MA2.Method +"("+ MA2.Periods +") upper band");
-   SetIndexLabel (MODE_MA2_LOWER_BAND, MA2.Method +"("+ MA2.Periods +") lower band");
+   SetIndexBuffer(MODE_MA2_UPPER, ma2.upperBand);
+   SetIndexBuffer(MODE_MA2_LOWER, ma2.lowerBand);
+   SetIndexStyle (MODE_MA2_UPPER, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
+   SetIndexStyle (MODE_MA2_LOWER, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
+   SetIndexLabel (MODE_MA2_UPPER, MA2.Method +"("+ MA2.Periods +") upper band");
+   SetIndexLabel (MODE_MA2_LOWER, MA2.Method +"("+ MA2.Periods +") lower band");
 
-   SetIndexBuffer(MODE_MA3_UPPER_BAND, ma3.upperBand);
-   SetIndexBuffer(MODE_MA3_LOWER_BAND, ma3.lowerBand);
-   SetIndexStyle (MODE_MA3_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
-   SetIndexStyle (MODE_MA3_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
-   SetIndexLabel (MODE_MA3_UPPER_BAND, MA3.Method +"("+ MA3.Periods +") upper band");
-   SetIndexLabel (MODE_MA3_LOWER_BAND, MA3.Method +"("+ MA3.Periods +") lower band");
+   SetIndexBuffer(MODE_MA3_UPPER, ma3.upperBand);
+   SetIndexBuffer(MODE_MA3_LOWER, ma3.lowerBand);
+   SetIndexStyle (MODE_MA3_UPPER, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
+   SetIndexStyle (MODE_MA3_LOWER, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
+   SetIndexLabel (MODE_MA3_UPPER, MA3.Method +"("+ MA3.Periods +") upper band");
+   SetIndexLabel (MODE_MA3_LOWER, MA3.Method +"("+ MA3.Periods +") lower band");
 
    if (!ma1.periods) {
-      SetIndexStyle(MODE_MA1_UPPER_BAND, DRAW_NONE);
-      SetIndexStyle(MODE_MA1_LOWER_BAND, DRAW_NONE);
-      SetIndexLabel(MODE_MA1_UPPER_BAND, NULL);
-      SetIndexLabel(MODE_MA1_LOWER_BAND, NULL);
+      SetIndexStyle(MODE_MA1_UPPER, DRAW_NONE);
+      SetIndexStyle(MODE_MA1_LOWER, DRAW_NONE);
+      SetIndexLabel(MODE_MA1_UPPER, NULL);
+      SetIndexLabel(MODE_MA1_LOWER, NULL);
    }
    if (!ma2.periods) {
-      SetIndexStyle(MODE_MA2_UPPER_BAND, DRAW_NONE);
-      SetIndexStyle(MODE_MA2_LOWER_BAND, DRAW_NONE);
-      SetIndexLabel(MODE_MA2_UPPER_BAND, NULL);
-      SetIndexLabel(MODE_MA2_LOWER_BAND, NULL);
+      SetIndexStyle(MODE_MA2_UPPER, DRAW_NONE);
+      SetIndexStyle(MODE_MA2_LOWER, DRAW_NONE);
+      SetIndexLabel(MODE_MA2_UPPER, NULL);
+      SetIndexLabel(MODE_MA2_LOWER, NULL);
    }
    if (!ma3.periods) {
-      SetIndexStyle(MODE_MA3_UPPER_BAND, DRAW_NONE);
-      SetIndexStyle(MODE_MA3_LOWER_BAND, DRAW_NONE);
-      SetIndexLabel(MODE_MA3_UPPER_BAND, NULL);
-      SetIndexLabel(MODE_MA3_LOWER_BAND, NULL);
+      SetIndexStyle(MODE_MA3_UPPER, DRAW_NONE);
+      SetIndexStyle(MODE_MA3_LOWER, DRAW_NONE);
+      SetIndexLabel(MODE_MA3_UPPER, NULL);
+      SetIndexLabel(MODE_MA3_LOWER, NULL);
    }
 
    if (redraw) WindowRedraw();

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -1,8 +1,19 @@
 /**
  * MA Channel
  *
- * An indicator forming a High/Low channel around a Moving Average. A single instance can display up to 3 channels
- * from multiple MAs. Supported MA types: SMA, LWMA, EMA, SMMA, ALMA.
+ * An indicator forming a High/Low channel around a Moving Average. The indicator can display up to 3 separate channels.
+ * This indicator is the core element of the XARD Trend indicator.
+ *
+ *
+ * Input parameters
+ * ----------------
+ *  • ...
+ *  • ...
+ *
+ *
+ * Usage with iCustom()
+ * --------------------
+ * @see /mql40/include/rsf/functions/iCustom/MaChannel.mqh
  *
  *
  * TODO:
@@ -14,15 +25,25 @@ int __DeinitFlags[];
 
 ////////////////////////////////////////////////////// Configuration ////////////////////////////////////////////////////////
 
-extern string Channel.Definition             = "EMA(144)";              // one or more MAs, e.g "EMA(144), LWMA(55)"
-extern color  Channel.Color                  = Magenta;
+extern string ___a__________________________ = "=== MA definitions ===";
+extern string MA1.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA1.Periods = 100;
+extern color  MA1.Color   = Magenta;
 
-extern string ___a__________________________ = "=== Display options ===";
+extern string MA2.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA2.Periods = 0;
+extern color  MA2.Color   = Blue;
+
+extern string MA3.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA3.Periods = 0;
+extern color  MA3.Color   = Red;
+
+extern string ___b__________________________ = "=== Display options ===";
 extern bool   ShowChartLegend                = true;
 extern int    MaxBarsBack                    = 10000;                   // max. values to calculate (-1: all available)
 
-extern string ___b__________________________ = "=== Signaling ===";
-extern bool   Signal.onBarCross              = false;                   // on BarClose crossing the opposite side of the channel
+extern string ___c__________________________ = "=== Signaling ===";
+extern bool   Signal.onBarCross              = false;                   // on BarClose crossing the most outer channel
 extern string Signal.onBarCross.Types        = "sound* | alert | mail | telegram";
 extern string Signal.Sound.Up                = "Signal Up.wav";
 extern string Signal.Sound.Down              = "Signal Down.wav";
@@ -39,26 +60,35 @@ extern string Signal.Sound.Down              = "Signal Down.wav";
 #include <rsf/functions/iCustom/MaChannel.mqh>
 #include <rsf/win32api.mqh>
 
-#define MODE_UPPER_BAND       MaChannel.MODE_UPPER_BAND  // 0 indicator buffer ids
-#define MODE_LOWER_BAND       MaChannel.MODE_LOWER_BAND  // 1
-#define MODE_TREND            MaChannel.MODE_TREND       // 2 direction/length of the last channel crossing, up: +1...+n, down: -1...-n
+#define MODE_MA1_UPPER_BAND   MaChannel.MODE_MA1_UPPER_BAND    // 0 indicator buffer ids
+#define MODE_MA1_LOWER_BAND   MaChannel.MODE_MA1_LOWER_BAND    // 1
+#define MODE_MA2_UPPER_BAND   MaChannel.MODE_MA2_UPPER_BAND    // 2
+#define MODE_MA2_LOWER_BAND   MaChannel.MODE_MA2_LOWER_BAND    // 3
+#define MODE_MA3_UPPER_BAND   MaChannel.MODE_MA3_UPPER_BAND    // 4
+#define MODE_MA3_LOWER_BAND   MaChannel.MODE_MA3_LOWER_BAND    // 5
 
 #property indicator_chart_window
-#property indicator_buffers   3                          // visible buffers
+#property indicator_buffers   6                          // visible buffers
 
 #property indicator_color1    CLR_NONE
 #property indicator_color2    CLR_NONE
 #property indicator_color3    CLR_NONE
 
-double upperBand[];                                      // upper band:      visible
-double lowerBand[];                                      // lower band:      visible
-double trend    [];                                      // trend direction: invisible, displayed in "Data" window
+int    ma1.method;                                       // MA definition
+int    ma1.periods;                                      //
+double ma1.upperBand[];                                  // indicator buffers
+double ma1.lowerBand[];                                  //
 
-#define MA_METHOD    0                                   // indexes of ma[]
-#define MA_PERIODS   1
+int    ma2.method;
+int    ma2.periods;
+double ma2.upperBand[];
+double ma2.lowerBand[];
 
-string sMaDefinitions[];                                 // MA definitions (human-readable)
-int    iMaDefinitions[][2];                              // MA definitions (numeric)
+int    ma3.method;
+int    ma3.periods;
+double ma3.upperBand[];
+double ma3.lowerBand[];
+
 int    maxMaPeriods;
 
 string indicatorName = "";
@@ -83,46 +113,61 @@ int onInit() {
    // input validation
    string indicator = WindowExpertName();
 
-   // Channel.Definition
-   ArrayResize(iMaDefinitions, 0);
-   ArrayResize(sMaDefinitions, 0);
-   int sizeMas = 0;
-   maxMaPeriods = 0;
-
-   string sValues[], sValue = Channel.Definition;
-   if (AutoConfiguration) sValue = GetConfigString(indicator, "Channel.Definition", sValue);
-   int size = Explode(sValue, ",", sValues, NULL);
-   for (int i=0; i < size; i++) {
-      sValue = StrTrim(sValues[i]);
-      if (sValue == "") continue;
-
-      string sMethod = StrLeftTo(sValue, "(");
-      if (sMethod == sValue)           return(catch("onInit(1)  invalid "+ DoubleQuoteStr(sValue) +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (expected format: \"MaMethod(int)\")", ERR_INVALID_INPUT_PARAMETER));
-      int iMethod = StrToMaMethod(sMethod, F_ERR_INVALID_PARAMETER);
-      if (iMethod == -1)               return(catch("onInit(2)  invalid "+ DoubleQuoteStr(sMethod) +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (unsupported MA method)", ERR_INVALID_INPUT_PARAMETER));
-      if (iMethod > MODE_LWMA)         return(catch("onInit(3)  invalid "+ DoubleQuoteStr(sMethod) +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (unsupported MA method)", ERR_INVALID_INPUT_PARAMETER));
-
-      string sPeriods = StrRightFrom(sValue, "(");
-      if (!StrEndsWith(sPeriods, ")")) return(catch("onInit(4)  invalid "+ DoubleQuoteStr(sValue) +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (expected format: \"MaMethod(int)\")", ERR_INVALID_INPUT_PARAMETER));
-      sPeriods = StrTrim(StrLeft(sPeriods, -1));
-      if (!StrIsDigits(sPeriods))      return(catch("onInit(5)  invalid "+ DoubleQuoteStr(sValue) +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (expected format: \"MaMethod(int)\")", ERR_INVALID_INPUT_PARAMETER));
-      int iPeriods = StrToInteger(sPeriods);
-      if (iPeriods < 1)                return(catch("onInit(6)  invalid MA periods "+ iPeriods +" in input parameter Channel.Definition: "+ DoubleQuoteStr(Channel.Definition) +" (must be positive)", ERR_INVALID_INPUT_PARAMETER));
-
-      ArrayResize(iMaDefinitions, sizeMas+1);
-      ArrayResize(sMaDefinitions, sizeMas+1);
-      iMaDefinitions[sizeMas][MA_METHOD ] = iMethod;
-      iMaDefinitions[sizeMas][MA_PERIODS] = iPeriods;
-      sMaDefinitions[sizeMas] = MaMethodDescription(iMethod) +"("+ iPeriods +")";
-      maxMaPeriods = MathMax(maxMaPeriods, iPeriods);
-      sizeMas++;
+   // MA1.Method
+   if (AutoConfiguration) MA1.Method = GetConfigString(indicator, "MA1.Method", MA1.Method);
+   string sValues[], sValue = MA1.Method;
+   if (Explode(sValue, "*", sValues, 2) > 1) {
+      int size = Explode(sValues[0], "|", sValues, NULL);
+      sValue = sValues[size-1];
    }
-   if (!sizeMas)                       return(catch("onInit(7)  missing input parameter Channel.Definition", ERR_INVALID_INPUT_PARAMETER));
-   Channel.Definition = JoinStrings(sMaDefinitions, ",");
+   ma1.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+   if (ma1.method == -1) return(catch("onInit(1)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
+   MA1.Method = MaMethodDescription(ma1.method);
+   // MA1.Periods
+   if (AutoConfiguration) MA1.Periods = GetConfigInt(indicator, "MA1.Periods", MA1.Periods);
+   if (MA1.Periods < 0)  return(catch("onInit(2)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   ma1.periods = MA1.Periods;
 
-   // Channel.Color: after deserialization the terminal may turn CLR_NONE (0xFFFFFFFF) into Black (0xFF000000)
-   if (AutoConfiguration) Channel.Color = GetConfigColor(indicator, "Channel.Color", Channel.Color);
-   if (Channel.Color == 0xFF000000) Channel.Color = CLR_NONE;
+   // MA2.Method
+   if (AutoConfiguration) MA2.Method = GetConfigString(indicator, "MA2.Method", MA2.Method);
+   sValue = MA2.Method;
+   if (Explode(sValue, "*", sValues, 2) > 1) {
+      size = Explode(sValues[0], "|", sValues, NULL);
+      sValue = sValues[size-1];
+   }
+   ma2.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+   if (ma2.method == -1) return(catch("onInit(3)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
+   MA2.Method = MaMethodDescription(ma2.method);
+   // MA2.Periods
+   if (AutoConfiguration) MA2.Periods = GetConfigInt(indicator, "MA2.Periods", MA2.Periods);
+   if (MA2.Periods < 0)  return(catch("onInit(4)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   ma2.periods = MA2.Periods;
+
+   // MA3.Method
+   if (AutoConfiguration) MA3.Method = GetConfigString(indicator, "MA3.Method", MA3.Method);
+   sValue = MA3.Method;
+   if (Explode(sValue, "*", sValues, 2) > 1) {
+      size = Explode(sValues[0], "|", sValues, NULL);
+      sValue = sValues[size-1];
+   }
+   ma3.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+   if (ma3.method == -1) return(catch("onInit(5)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
+   MA3.Method = MaMethodDescription(ma3.method);
+   // MA3.Periods
+   if (AutoConfiguration) MA3.Periods = GetConfigInt(indicator, "MA3.Periods", MA3.Periods);
+   if (MA3.Periods < 0)  return(catch("onInit(6)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   ma3.periods = MA3.Periods;
+   maxMaPeriods = Max(ma1.periods, ma2.periods, ma3.periods);
+   if (!maxMaPeriods)    return(catch("onInit(7)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
+
+   // colors: after deserialization the terminal may turn CLR_NONE (0xFFFFFFFF) into Black (0xFF000000)
+   if (AutoConfiguration) MA1.Color = GetConfigColor(indicator, "MA1.Color", MA1.Color);
+   if (AutoConfiguration) MA2.Color = GetConfigColor(indicator, "MA2.Color", MA2.Color);
+   if (AutoConfiguration) MA3.Color = GetConfigColor(indicator, "MA3.Color", MA3.Color);
+   if (MA1.Color == 0xFF000000) MA1.Color = CLR_NONE;
+   if (MA2.Color == 0xFF000000) MA2.Color = CLR_NONE;
+   if (MA3.Color == 0xFF000000) MA3.Color = CLR_NONE;
+
    // ShowChartLegend
    if (AutoConfiguration) ShowChartLegend = GetConfigBool(indicator, "ShowChartLegend", ShowChartLegend);
    // MaxBarsBack
@@ -161,49 +206,52 @@ int onInit() {
 int onTick() {
    // reset buffers before performing a full recalculation
    if (!ValidBars) {
-      ArrayInitialize(upperBand, EMPTY_VALUE);
-      ArrayInitialize(lowerBand, EMPTY_VALUE);
-      ArrayInitialize(trend,               0);
+      ArrayInitialize(ma1.upperBand, EMPTY_VALUE);
+      ArrayInitialize(ma1.lowerBand, EMPTY_VALUE);
+      ArrayInitialize(ma2.upperBand, EMPTY_VALUE);
+      ArrayInitialize(ma2.lowerBand, EMPTY_VALUE);
+      ArrayInitialize(ma3.upperBand, EMPTY_VALUE);
+      ArrayInitialize(ma3.lowerBand, EMPTY_VALUE);
       SetIndicatorOptions();
    }
 
    // synchronize buffers with a shifted offline chart
    if (ShiftedBars > 0) {
-      ShiftDoubleIndicatorBuffer(upperBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(trend,     Bars, ShiftedBars,           0);
+      ShiftDoubleIndicatorBuffer(ma1.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma1.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma2.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma2.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma3.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma3.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
    }
 
    // calculate start bar
-   int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods), prevTrend;
+   int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods);
    if (startbar < 0 && MaxBarsBack) return(logInfo("onTick(1)  Tick="+ Ticks, ERR_HISTORY_INSUFFICIENT));
-
-   int sizeMas = ArrayRange(iMaDefinitions, 0);
 
    // recalculate changed bars
    for (int bar=startbar; bar >= 0; bar--) {
-      double high = INT_MIN, low = INT_MAX;
-
-      for (int i=0; i < sizeMas; i++) {
-         high = MathMax(high, iMA(NULL, NULL, iMaDefinitions[i][MA_PERIODS], 0, iMaDefinitions[i][MA_METHOD], PRICE_HIGH, bar));
-         low  = MathMin(low,  iMA(NULL, NULL, iMaDefinitions[i][MA_PERIODS], 0, iMaDefinitions[i][MA_METHOD], PRICE_LOW,  bar));
+      if (ma1.periods > 0) {
+         ma1.upperBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_HIGH, bar);
+         ma1.lowerBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_LOW,  bar);
       }
-      upperBand[bar] = high;
-      lowerBand[bar] = low;
-
-      prevTrend = trend[bar+1];
-      if      (Close[bar] > upperBand[bar]) trend[bar] = Max(prevTrend, 0) + 1;
-      else if (Close[bar] < lowerBand[bar]) trend[bar] = Min(prevTrend, 0) - 1;
-      else                                  trend[bar] = prevTrend + Sign(prevTrend);
+      if (ma2.periods > 0) {
+         ma2.upperBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_HIGH, bar);
+         ma2.lowerBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_LOW,  bar);
+      }
+      if (ma3.periods > 0) {
+         ma3.upperBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_HIGH, bar);
+         ma3.lowerBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_LOW,  bar);
+      }
    }
 
-   if (!__isSuperContext) {
-      if (ShowChartLegend) UpdateBandLegend(legendLabel, indicatorName, legendInfo, Channel.Color, upperBand[0], lowerBand[0]);
+   if (__isChart && !__isSuperContext) {
+      //if (ShowChartLegend) UpdateBandLegend(legendLabel, indicatorName, legendInfo, Channel.Color, upperBand[0], lowerBand[0]);
 
       // monitor signals
       if (Signal.onBarCross) /*&&*/ if (IsBarOpen()) {
-         if      (trend[1] ==  1) onCross(D_LONG);
-         else if (trend[1] == -1) onCross(D_SHORT);
+         //if      (trend[1] ==  1) onCross(D_LONG);
+         //else if (trend[1] == -1) onCross(D_SHORT);
       }
    }
    return(last_error);
@@ -299,23 +347,52 @@ bool onCross(int direction) {
  * @return bool - success status
  */
 bool SetIndicatorOptions(bool redraw = false) {
-   redraw = redraw!=0;
+   redraw = (redraw != 0);
    indicatorName = GetChannelDescription();
    IndicatorShortName(indicatorName);
 
    IndicatorBuffers(indicator_buffers);
-   SetIndexBuffer(MODE_UPPER_BAND, upperBand);
-   SetIndexBuffer(MODE_LOWER_BAND, lowerBand);
-   SetIndexBuffer(MODE_TREND,      trend    ); SetIndexEmptyValue(MODE_TREND, 0);
    IndicatorDigits(Digits);
 
-   SetIndexStyle(MODE_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, Channel.Color);
-   SetIndexStyle(MODE_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, Channel.Color);
-   SetIndexStyle(MODE_TREND,      DRAW_NONE);
+   SetIndexBuffer(MODE_MA1_UPPER_BAND, ma1.upperBand);
+   SetIndexBuffer(MODE_MA1_LOWER_BAND, ma1.lowerBand);
+   SetIndexStyle (MODE_MA1_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
+   SetIndexStyle (MODE_MA1_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA1.Color);
+   SetIndexLabel (MODE_MA1_UPPER_BAND, MA1.Method +"("+ MA1.Periods +") upper band");
+   SetIndexLabel (MODE_MA1_LOWER_BAND, MA1.Method +"("+ MA1.Periods +") lower band");
 
-   SetIndexLabel(MODE_UPPER_BAND, indicatorName +" upper");
-   SetIndexLabel(MODE_LOWER_BAND, indicatorName +" lower");
-   SetIndexLabel(MODE_TREND,      NULL);
+   SetIndexBuffer(MODE_MA2_UPPER_BAND, ma2.upperBand);
+   SetIndexBuffer(MODE_MA2_LOWER_BAND, ma2.lowerBand);
+   SetIndexStyle (MODE_MA2_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
+   SetIndexStyle (MODE_MA2_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA2.Color);
+   SetIndexLabel (MODE_MA2_UPPER_BAND, MA2.Method +"("+ MA2.Periods +") upper band");
+   SetIndexLabel (MODE_MA2_LOWER_BAND, MA2.Method +"("+ MA2.Periods +") lower band");
+
+   SetIndexBuffer(MODE_MA3_UPPER_BAND, ma3.upperBand);
+   SetIndexBuffer(MODE_MA3_LOWER_BAND, ma3.lowerBand);
+   SetIndexStyle (MODE_MA3_UPPER_BAND, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
+   SetIndexStyle (MODE_MA3_LOWER_BAND, DRAW_LINE, EMPTY, EMPTY, MA3.Color);
+   SetIndexLabel (MODE_MA3_UPPER_BAND, MA3.Method +"("+ MA3.Periods +") upper band");
+   SetIndexLabel (MODE_MA3_LOWER_BAND, MA3.Method +"("+ MA3.Periods +") lower band");
+
+   if (!ma1.periods) {
+      SetIndexStyle(MODE_MA1_UPPER_BAND, DRAW_NONE);
+      SetIndexStyle(MODE_MA1_LOWER_BAND, DRAW_NONE);
+      SetIndexLabel(MODE_MA1_UPPER_BAND, NULL);
+      SetIndexLabel(MODE_MA1_LOWER_BAND, NULL);
+   }
+   if (!ma2.periods) {
+      SetIndexStyle(MODE_MA2_UPPER_BAND, DRAW_NONE);
+      SetIndexStyle(MODE_MA2_LOWER_BAND, DRAW_NONE);
+      SetIndexLabel(MODE_MA2_UPPER_BAND, NULL);
+      SetIndexLabel(MODE_MA2_LOWER_BAND, NULL);
+   }
+   if (!ma3.periods) {
+      SetIndexStyle(MODE_MA3_UPPER_BAND, DRAW_NONE);
+      SetIndexStyle(MODE_MA3_LOWER_BAND, DRAW_NONE);
+      SetIndexLabel(MODE_MA3_UPPER_BAND, NULL);
+      SetIndexLabel(MODE_MA3_LOWER_BAND, NULL);
+   }
 
    if (redraw) WindowRedraw();
    return(!catch("SetIndicatorOptions(1)"));
@@ -328,31 +405,34 @@ bool SetIndicatorOptions(bool redraw = false) {
  * @return string
  */
 string GetChannelDescription() {
-   string sMethod = "", sameMethods = "", differentMethods = "";
+   string sameMethods = "", differentMethods = "";
    bool allSameMethod = true;
-   int size = ArrayRange(iMaDefinitions, 0), method, periods;
 
-   if (size == 1) {
-      sameMethods = sMaDefinitions[0] +" Channel";
+   if (ma1.periods > 0) {
+      sameMethods      = MA1.Method +"("+ MA1.Periods;
+      differentMethods = differentMethods +","+ MA1.Method +"("+ MA1.Periods +")";
    }
-   else {
-      for (int i=0; i < size; i++) {
-         method  = iMaDefinitions[i][MA_METHOD];
-         periods = iMaDefinitions[i][MA_PERIODS];
-         sMethod = MaMethodDescription(method);
+   if (ma2.periods > 0) {
+      sameMethods      = sameMethods +","+ MA2.Periods;
+      differentMethods = differentMethods +","+ MA2.Method +"("+ MA2.Periods +")";
 
-         if (i && allSameMethod) {
-            allSameMethod = (method == iMaDefinitions[i-1][MA_METHOD]);
-         }
-         if (allSameMethod) {
-            if (i == 0) sameMethods = sMethod +"("+ periods;
-            else        sameMethods = sameMethods +","+ periods;
-         }
-         differentMethods = StringConcatenate(differentMethods, ",", sMethod, "(", periods, ")");
+      if (ma1.periods > 0) {
+         allSameMethod = (ma1.method == ma2.method);
       }
-      sameMethods      = sameMethods +") Channel";
-      differentMethods = StrRight(differentMethods, -1) +" Channel";
    }
+   if (ma3.periods > 0) {
+      sameMethods      = sameMethods +","+ MA3.Periods;
+      differentMethods = differentMethods +","+ MA3.Method +"("+ MA3.Periods +")";
+
+      if (ma1.periods > 0) {
+         allSameMethod = (ma1.method == ma3.method);
+      }
+      if (ma2.periods > 0) {
+         allSameMethod = (ma2.method == ma3.method);
+      }
+   }
+   sameMethods      = sameMethods +") Channel";
+   differentMethods = StrRight(differentMethods, -1) +" Channel";
 
    if (allSameMethod)
       return(sameMethods);
@@ -366,16 +446,27 @@ string GetChannelDescription() {
  * @return string
  */
 string InputsToStr() {
-   return(StringConcatenate("Channel.Definition=",      DoubleQuoteStr(Channel.Definition),      ";", NL,
-                            "Channel.Color=",           ColorToStr(Channel.Color),               ";", NL,
-                            "ShowChartLegend=",         BoolToStr(ShowChartLegend),              ";", NL,
-                            "MaxBarsBack=",             MaxBarsBack,                             ";", NL,
+   return(StringConcatenate(
+      "MA1.Method=",              DoubleQuoteStr(MA1.Method),              ";", NL,
+      "MA1.Periods=",             MA1.Periods,                             ";", NL,
+      "MA1.Color=",               ColorToStr(MA1.Color),                   ";", NL,
 
-                            "Signal.onBarCross=",       BoolToStr(Signal.onBarCross),            ";", NL,
-                            "Signal.onBarCross.Types=", DoubleQuoteStr(Signal.onBarCross.Types), ";", NL,
-                            "Signal.Sound.Up=",         DoubleQuoteStr(Signal.Sound.Up),         ";", NL,
-                            "Signal.Sound.Down=",       DoubleQuoteStr(Signal.Sound.Down),       ";")
-   );
+      "MA2.Method=",              DoubleQuoteStr(MA2.Method),              ";", NL,
+      "MA2.Periods=",             MA2.Periods,                             ";", NL,
+      "MA2.Color=",               ColorToStr(MA2.Color),                   ";", NL,
+
+      "MA3.Method=",              DoubleQuoteStr(MA3.Method),              ";", NL,
+      "MA3.Periods=",             MA3.Periods,                             ";", NL,
+      "MA3.Color=",               ColorToStr(MA3.Color),                   ";", NL,
+
+      "ShowChartLegend=",         BoolToStr(ShowChartLegend),              ";", NL,
+      "MaxBarsBack=",             MaxBarsBack,                             ";", NL,
+
+      "Signal.onBarCross=",       BoolToStr(Signal.onBarCross),            ";", NL,
+      "Signal.onBarCross.Types=", DoubleQuoteStr(Signal.onBarCross.Types), ";", NL,
+      "Signal.Sound.Up=",         DoubleQuoteStr(Signal.Sound.Up),         ";", NL,
+      "Signal.Sound.Down=",       DoubleQuoteStr(Signal.Sound.Down),       ";", NL
+   ));
 
    // suppress compiler warnings
    icMaChannel(NULL, NULL, NULL, NULL);

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -113,50 +113,65 @@ int onInit() {
    // input validation
    string indicator = WindowExpertName();
 
-   // MA1.Method
-   if (AutoConfiguration) MA1.Method = GetConfigString(indicator, "MA1.Method", MA1.Method);
-   string sValues[], sValue = MA1.Method;
-   if (Explode(sValue, "*", sValues, 2) > 1) {
-      int size = Explode(sValues[0], "|", sValues, NULL);
-      sValue = sValues[size-1];
-   }
-   ma1.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-   if (ma1.method == -1) return(catch("onInit(1)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
-   MA1.Method = MaMethodDescription(ma1.method);
-   // MA1.Periods
+   // MA1.Periods (must be checked before MA.Method)
    if (AutoConfiguration) MA1.Periods = GetConfigInt(indicator, "MA1.Periods", MA1.Periods);
-   if (MA1.Periods < 0)  return(catch("onInit(2)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA1.Periods < 0)  return(catch("onInit(1)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma1.periods = MA1.Periods;
-
-   // MA2.Method
-   if (AutoConfiguration) MA2.Method = GetConfigString(indicator, "MA2.Method", MA2.Method);
-   sValue = MA2.Method;
-   if (Explode(sValue, "*", sValues, 2) > 1) {
-      size = Explode(sValues[0], "|", sValues, NULL);
-      sValue = sValues[size-1];
+   // MA1.Method
+   if (!ma1.periods) {
+      MA1.Method = "";
    }
-   ma2.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-   if (ma2.method == -1) return(catch("onInit(3)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
-   MA2.Method = MaMethodDescription(ma2.method);
+   else {
+      if (AutoConfiguration) MA1.Method = GetConfigString(indicator, "MA1.Method", MA1.Method);
+      string sValues[], sValue = MA1.Method;
+      if (Explode(sValue, "*", sValues, 2) > 1) {
+         int size = Explode(sValues[0], "|", sValues, NULL);
+         sValue = sValues[size-1];
+      }
+      ma1.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+      if (ma1.method == -1) return(catch("onInit(2)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
+      MA1.Method = MaMethodDescription(ma1.method);
+   }
+
    // MA2.Periods
    if (AutoConfiguration) MA2.Periods = GetConfigInt(indicator, "MA2.Periods", MA2.Periods);
-   if (MA2.Periods < 0)  return(catch("onInit(4)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA2.Periods < 0)  return(catch("onInit(3)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma2.periods = MA2.Periods;
-
-   // MA3.Method
-   if (AutoConfiguration) MA3.Method = GetConfigString(indicator, "MA3.Method", MA3.Method);
-   sValue = MA3.Method;
-   if (Explode(sValue, "*", sValues, 2) > 1) {
-      size = Explode(sValues[0], "|", sValues, NULL);
-      sValue = sValues[size-1];
+   // MA2.Method
+   if (!ma2.periods) {
+      MA2.Method = "";
    }
-   ma3.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-   if (ma3.method == -1) return(catch("onInit(5)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
-   MA3.Method = MaMethodDescription(ma3.method);
+   else {
+      if (AutoConfiguration) MA2.Method = GetConfigString(indicator, "MA2.Method", MA2.Method);
+      sValue = MA2.Method;
+      if (Explode(sValue, "*", sValues, 2) > 1) {
+         size = Explode(sValues[0], "|", sValues, NULL);
+         sValue = sValues[size-1];
+      }
+      ma2.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+      if (ma2.method == -1) return(catch("onInit(4)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
+      MA2.Method = MaMethodDescription(ma2.method);
+   }
+
    // MA3.Periods
    if (AutoConfiguration) MA3.Periods = GetConfigInt(indicator, "MA3.Periods", MA3.Periods);
-   if (MA3.Periods < 0)  return(catch("onInit(6)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA3.Periods < 0)  return(catch("onInit(5)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma3.periods = MA3.Periods;
+   // MA3.Method
+   if (!ma3.periods) {
+      MA3.Method = "";
+   }
+   else {
+      if (AutoConfiguration) MA3.Method = GetConfigString(indicator, "MA3.Method", MA3.Method);
+      sValue = MA3.Method;
+      if (Explode(sValue, "*", sValues, 2) > 1) {
+         size = Explode(sValues[0], "|", sValues, NULL);
+         sValue = sValues[size-1];
+      }
+      ma3.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
+      if (ma3.method == -1) return(catch("onInit(6)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
+      MA3.Method = MaMethodDescription(ma3.method);
+   }
    maxMaPeriods = Max(ma1.periods, ma2.periods, ma3.periods);
    if (!maxMaPeriods)    return(catch("onInit(7)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
 

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -2,7 +2,7 @@
  * MA Channel
  *
  * An indicator forming a High/Low channel around a Moving Average. The indicator can display up to 3 separate channels.
- * This indicator is the core element of the XARD Trend indicator.
+ * This indicator provides the foundation for the XARD trend system.
  *
  *
  * Input parameters

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -831,7 +831,8 @@ string GetChannelDescription() {
       differentMethods = differentMethods +","+ MA1.Method +"("+ MA1.Periods +")";
    }
    if (ma2.enabled) {
-      sameMethods      = sameMethods +","+ MA2.Periods;
+      if (sameMethods == "") sameMethods = MA2.Method +"("+ MA2.Periods;
+      else                   sameMethods = sameMethods +","+ MA2.Periods;
       differentMethods = differentMethods +","+ MA2.Method +"("+ MA2.Periods +")";
 
       if (ma1.enabled) {
@@ -839,7 +840,8 @@ string GetChannelDescription() {
       }
    }
    if (ma3.enabled) {
-      sameMethods      = sameMethods +","+ MA3.Periods;
+      if (sameMethods == "") sameMethods = MA3.Method +"("+ MA3.Periods;
+      else                   sameMethods = sameMethods +","+ MA3.Periods;
       differentMethods = differentMethods +","+ MA3.Method +"("+ MA3.Periods +")";
 
       if (ma1.enabled) {

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -76,9 +76,9 @@ extern string Signal.Sound.Down              = "Signal Down.wav";
 #include <rsf/functions/chartlegend.mqh>
 #include <rsf/functions/ConfigureSignals.mqh>
 #include <rsf/functions/IsBarOpen.mqh>
+#include <rsf/functions/ManageIntIndicatorBuffer.mqh>
 #include <rsf/functions/ObjectCreateRegister.mqh>
 #include <rsf/functions/iCustom/MaChannel.mqh>
-#include <rsf/functions/ManageIntIndicatorBuffer.mqh>
 #include <rsf/functions/ta/ALMA.mqh>
 
 #define MODE_MA1_UPPER  MaChannel.MODE_MA1_UPPER_BAND    // 0 indicator buffer ids
@@ -143,8 +143,9 @@ double channelTrend[];                                   // overall channel tren
 int    maxMaPeriods;
 
 string indicatorName = "";
-string legendLabel   = "";
-string legendInfo    = "";
+string legendLabel = "";
+string legendInfo = "";
+color  legendColor;
 
 bool   signal.sound;
 bool   signal.alert;
@@ -252,6 +253,9 @@ int onInit() {
    if (MA1.Color == 0xFF000000) MA1.Color = CLR_NONE;
    if (MA2.Color == 0xFF000000) MA2.Color = CLR_NONE;
    if (MA3.Color == 0xFF000000) MA3.Color = CLR_NONE;
+   if      (ma1.enabled) legendColor = MA1.Color;
+   else if (ma2.enabled) legendColor = MA2.Color;
+   else                  legendColor = MA3.Color;
 
    // ShowChartLegend
    if (AutoConfiguration) ShowChartLegend = GetConfigBool(indicator, "ShowChartLegend", ShowChartLegend);
@@ -281,10 +285,10 @@ int onInit() {
    if (ma2.method == MODE_ALMA) ALMA.CalculateWeights(ma2.periods, almaOffset, almaSigma, ma2.almaWeights);
    if (ma3.method == MODE_ALMA) ALMA.CalculateWeights(ma3.periods, almaOffset, almaSigma, ma3.almaWeights);
 
-   // chart legend
+   // buffer management and display options
+   SetIndicatorOptions();
    if (ShowChartLegend) legendLabel = CreateChartLegend();
 
-   SetIndicatorOptions();
    return(catch("onInit(13)"));
 }
 
@@ -474,7 +478,7 @@ int onTick() {
    }
 
    if (__isChart && !__isSuperContext) {
-      //if (ShowChartLegend) UpdateBandLegend(legendLabel, indicatorName, legendInfo, Channel.Color, upperBand[0], lowerBand[0]);
+      if (ShowChartLegend) UpdateChartLegend();
 
       // monitor signals
       if (Signal.onBarCross) /*&&*/ if (IsBarOpen()) {
@@ -568,6 +572,63 @@ bool onCross(int direction) {
 
 
 /**
+ * Update the chart legend.
+ */
+void UpdateChartLegend() {
+   double upperValue = 0, lowerValue = INT_MAX;
+
+   if (channelPosition[0] > 0) {
+      // resolve the nearest lower channel band
+      if (ma1.enabled) upperValue = ma1.lowerBand[0];
+      if (ma2.enabled) upperValue = MathMax(upperValue, ma2.lowerBand[0]);
+      if (ma3.enabled) upperValue = MathMax(upperValue, ma3.lowerBand[0]);
+
+      // resolve the farest lower channel band
+      if (ma1.enabled) lowerValue = ma1.lowerBand[0];
+      if (ma2.enabled) lowerValue = MathMin(lowerValue, ma2.lowerBand[0]);
+      if (ma3.enabled) lowerValue = MathMin(lowerValue, ma3.lowerBand[0]);
+   }
+   else if (channelPosition[0] < 0) {
+      // resolve the farest upper channel band
+      if (ma1.enabled) upperValue = ma1.upperBand[0];
+      if (ma2.enabled) upperValue = MathMax(upperValue, ma2.upperBand[0]);
+      if (ma3.enabled) upperValue = MathMax(upperValue, ma3.upperBand[0]);
+
+      // resolve the nearest upper channel band
+      if (ma1.enabled) lowerValue = ma1.upperBand[0];
+      if (ma2.enabled) lowerValue = MathMin(lowerValue, ma2.upperBand[0]);
+      if (ma3.enabled) lowerValue = MathMin(lowerValue, ma3.upperBand[0]);
+   }
+   else {
+      // resolve the farest upper band
+      if (ma1.enabled) upperValue = ma1.upperBand[0];
+      if (ma2.enabled) upperValue = MathMax(upperValue, ma2.upperBand[0]);
+      if (ma3.enabled) upperValue = MathMax(upperValue, ma3.upperBand[0]);
+
+      // resolve the farest lower band
+      if (ma1.enabled) lowerValue = ma1.lowerBand[0];
+      if (ma2.enabled) lowerValue = MathMin(lowerValue, ma2.lowerBand[0]);
+      if (ma3.enabled) lowerValue = MathMin(lowerValue, ma3.lowerBand[0]);
+   }
+
+   string sUpperValue = NumberToStr(upperValue, PriceFormat);
+   string sLowerValue = NumberToStr(lowerValue, PriceFormat);
+   string text = StringConcatenate(indicatorName, "   ", sUpperValue, " / ", sLowerValue, "   ", legendInfo);
+
+   color  textColor = legendColor;
+   if      (textColor == Aqua        ) textColor = DodgerBlue;
+   else if (textColor == Gold        ) textColor = Orange;
+   else if (textColor == LightSkyBlue) textColor = C'94,174,255';
+   else if (textColor == Lime        ) textColor = LimeGreen;
+   else if (textColor == Yellow      ) textColor = Orange;
+   ObjectSetText(legendLabel, text, 9, "Arial Fett", textColor);
+
+   int error = GetLastError();                                    // on ObjectDrag or opened "Properties" dialog
+   if (error && error!=ERR_OBJECT_DOES_NOT_EXIST) catch("UpdateChartLegend(1)", error);
+}
+
+
+/**
  * Set indicator options. After recompilation the function must be called from start() for options not to be ignored.
  *
  * @param  bool redraw [optional] - whether to redraw the chart (default: no)
@@ -624,7 +685,7 @@ bool SetIndicatorOptions(bool redraw = false) {
 
    SetIndexBuffer(MODE_POSITION, channelPosition);
    SetIndexStyle (MODE_POSITION, DRAW_NONE);
-   SetIndexLabel (MODE_POSITION, NULL);
+   SetIndexLabel (MODE_POSITION, "MA Channel position");
 
    SetIndexBuffer(MODE_TREND, channelTrend);
    SetIndexStyle (MODE_TREND, DRAW_NONE);

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -250,8 +250,8 @@ int onTick() {
 
       // monitor signals
       if (Signal.onBarCross) /*&&*/ if (IsBarOpen()) {
-         //if      (trend[1] ==  1) onCross(D_LONG);
-         //else if (trend[1] == -1) onCross(D_SHORT);
+         if      (false) onCross(D_LONG);
+         else if (false) onCross(D_SHORT);
       }
    }
    return(last_error);
@@ -469,5 +469,5 @@ string InputsToStr() {
    ));
 
    // suppress compiler warnings
-   icMaChannel(NULL, NULL, NULL, NULL);
+   icMaChannel(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -340,8 +340,8 @@ int onTick() {
             ma1.upperBand[bar] = 0;
             ma1.lowerBand[bar] = 0;
             for (i=0; i < ma1.periods; i++) {
-               ma1.upperBand[bar] += ma1.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
-               ma1.lowerBand[bar] += ma1.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+               ma1.upperBand[bar] += ma1.almaWeights[i] * High[bar+i];
+               ma1.lowerBand[bar] += ma1.almaWeights[i] * Low [bar+i];
             }
          }
          else {
@@ -365,8 +365,8 @@ int onTick() {
             ma2.upperBand[bar] = 0;
             ma2.lowerBand[bar] = 0;
             for (i=0; i < ma2.periods; i++) {
-               ma2.upperBand[bar] += ma2.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
-               ma2.lowerBand[bar] += ma2.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+               ma2.upperBand[bar] += ma2.almaWeights[i] * High[bar+i];
+               ma2.lowerBand[bar] += ma2.almaWeights[i] * Low [bar+i];
             }
          }
          else {
@@ -390,8 +390,8 @@ int onTick() {
             ma3.upperBand[bar] = 0;
             ma3.lowerBand[bar] = 0;
             for (i=0; i < ma3.periods; i++) {
-               ma3.upperBand[bar] += ma3.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_HIGH, bar+i);
-               ma3.lowerBand[bar] += ma3.almaWeights[i] * iMA(NULL, NULL, 1, 0, MODE_SMA, PRICE_LOW, bar+i);
+               ma3.upperBand[bar] += ma3.almaWeights[i] * High[bar+i];
+               ma3.lowerBand[bar] += ma3.almaWeights[i] * Low [bar+i];
             }
          }
          else {

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -577,7 +577,7 @@ bool onCross(int direction) {
 void UpdateChartLegend() {
    double upperValue = 0, lowerValue = INT_MAX;
 
-   if (channelPosition[0] > 0) {
+   if (channelPosition[1] > 0) {
       // resolve the nearest lower channel band
       if (ma1.enabled) upperValue = ma1.lowerBand[0];
       if (ma2.enabled) upperValue = MathMax(upperValue, ma2.lowerBand[0]);
@@ -588,7 +588,7 @@ void UpdateChartLegend() {
       if (ma2.enabled) lowerValue = MathMin(lowerValue, ma2.lowerBand[0]);
       if (ma3.enabled) lowerValue = MathMin(lowerValue, ma3.lowerBand[0]);
    }
-   else if (channelPosition[0] < 0) {
+   else if (channelPosition[1] < 0) {
       // resolve the farest upper channel band
       if (ma1.enabled) upperValue = ma1.upperBand[0];
       if (ma2.enabled) upperValue = MathMax(upperValue, ma2.upperBand[0]);

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -16,8 +16,8 @@
  *  • SMA  = Simple Moving Average:          equal bar weighting
  *  • LWMA = Linear Weighted Moving Average: bar weighting using a linear function
  *  • EMA  = Exponential Moving Average:     bar weighting using an exponential function
- *  • SMMA = Smoothed Moving Average:        bar weighting using an exponential function (an EMA, see notes)
- *  • ALMA = Arnaud Legoux Moving Average:   bar weighting using a Gaussian function
+ *  • SMMA = Smoothed Moving Average:        bar weighting using an exponential function (an EMA of a different period)
+ *  • ALMA = Arnaud Legoux Moving Average:   bar weighting using a Gaussian function (see notes)
  *
  *
  * Usage with iCustom()
@@ -79,8 +79,8 @@ extern string Signal.Sound.Down              = "Signal Down.wav";
 #include <rsf/functions/IsBarOpen.mqh>
 #include <rsf/functions/ObjectCreateRegister.mqh>
 #include <rsf/functions/iCustom/MaChannel.mqh>
+#include <rsf/functions/ManageIntIndicatorBuffer.mqh>
 #include <rsf/functions/ta/ALMA.mqh>
-#include <rsf/win32api.mqh>
 
 #define MODE_MA1_UPPER  MaChannel.MODE_MA1_UPPER_BAND    // 0 indicator buffer ids
 #define MODE_MA1_LOWER  MaChannel.MODE_MA1_LOWER_BAND    // 1
@@ -88,31 +88,58 @@ extern string Signal.Sound.Down              = "Signal Down.wav";
 #define MODE_MA2_LOWER  MaChannel.MODE_MA2_LOWER_BAND    // 3
 #define MODE_MA3_UPPER  MaChannel.MODE_MA3_UPPER_BAND    // 4
 #define MODE_MA3_LOWER  MaChannel.MODE_MA3_LOWER_BAND    // 5
+#define MODE_POSITION   MaChannel.MODE_POSITION          // 6 price position inside/outside of the channel:    -1..0..+1
+#define MODE_TREND      MaChannel.MODE_TREND             // 7 trend/length of the last outer channel crossing: -n..0..+n
+
+#define MODE_MA1_POSITION   8                            // price position in relation to single MA channel: -1..0..+1
+#define MODE_MA1_TREND      9                            // single MA channel trend:                         -n..0..+n
+#define MODE_MA2_POSITION  10                            //
+#define MODE_MA2_TREND     11                            //
+#define MODE_MA3_POSITION  12                            //
+#define MODE_MA3_TREND     13                            //
 
 #property indicator_chart_window
-#property indicator_buffers   6                          // visible buffers
+#property indicator_buffers   8                          // buffers managed by the terminal
+int       framework_buffers = 6;                         // buffers managed by the framework
 
 #property indicator_color1    CLR_NONE
 #property indicator_color2    CLR_NONE
 #property indicator_color3    CLR_NONE
+#property indicator_color4    CLR_NONE
+#property indicator_color5    CLR_NONE
+#property indicator_color6    CLR_NONE
+#property indicator_color7    CLR_NONE
+#property indicator_color8    CLR_NONE
 
-int    ma1.method;                                       // MA definition
+bool   ma1.enabled;                                      // MA settings
+int    ma1.method;                                       //
 int    ma1.periods;                                      //
-double ma1.upperBand[];                                  // indicator buffers
+double ma1.upperBand[];                                  //
 double ma1.lowerBand[];                                  //
+int    ma1.position[];                                   //
+int    ma1.trend[];                                      //
 double ma1.almaWeights[];                                // ALMA bar weights (if applicable
 
+bool   ma2.enabled;
 int    ma2.method;
 int    ma2.periods;
 double ma2.upperBand[];
 double ma2.lowerBand[];
+int    ma2.position[];
+int    ma2.trend[];
 double ma2.almaWeights[];
 
+bool   ma3.enabled;
 int    ma3.method;
 int    ma3.periods;
 double ma3.upperBand[];
 double ma3.lowerBand[];
+int    ma3.position[];
+int    ma3.trend[];
 double ma3.almaWeights[];
+
+double channelPosition[];                                // overall price position in relation to channel: -1..0..+1
+double channelTrend[];                                   // overall channel trend (all MAs): -n..0..+n
 
 int    maxMaPeriods;
 
@@ -139,8 +166,9 @@ int onInit() {
    string indicator = WindowExpertName();
 
    // MA1.Periods (must be checked before MA.Method)
+   ma1.enabled = false;
    if (AutoConfiguration) MA1.Periods = GetConfigInt(indicator, "MA1.Periods", MA1.Periods);
-   if (MA1.Periods < 0)  return(catch("onInit(1)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA1.Periods < 0)     return(catch("onInit(1)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma1.periods = MA1.Periods;
    // MA1.Method
    if (!ma1.periods) {
@@ -156,11 +184,13 @@ int onInit() {
       ma1.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
       if (ma1.method == -1) return(catch("onInit(2)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
       MA1.Method = MaMethodDescription(ma1.method);
+      ma1.enabled = true;
    }
 
    // MA2.Periods
+   ma2.enabled = false;
    if (AutoConfiguration) MA2.Periods = GetConfigInt(indicator, "MA2.Periods", MA2.Periods);
-   if (MA2.Periods < 0)  return(catch("onInit(3)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA2.Periods < 0)     return(catch("onInit(3)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma2.periods = MA2.Periods;
    // MA2.Method
    if (!ma2.periods) {
@@ -176,11 +206,13 @@ int onInit() {
       ma2.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
       if (ma2.method == -1) return(catch("onInit(4)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
       MA2.Method = MaMethodDescription(ma2.method);
+      ma2.enabled = true;
    }
 
    // MA3.Periods
+   ma3.enabled = false;
    if (AutoConfiguration) MA3.Periods = GetConfigInt(indicator, "MA3.Periods", MA3.Periods);
-   if (MA3.Periods < 0)  return(catch("onInit(5)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA3.Periods < 0)     return(catch("onInit(5)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma3.periods = MA3.Periods;
    // MA3.Method
    if (!ma3.periods) {
@@ -196,9 +228,10 @@ int onInit() {
       ma3.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
       if (ma3.method == -1) return(catch("onInit(6)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
       MA3.Method = MaMethodDescription(ma3.method);
+      ma3.enabled = true;
    }
    maxMaPeriods = Max(ma1.periods, ma2.periods, ma3.periods);
-   if (!maxMaPeriods)    return(catch("onInit(7)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
+   if (!maxMaPeriods)       return(catch("onInit(7)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
 
    // colors: after deserialization the terminal may turn CLR_NONE (0xFFFFFFFF) into Black (0xFF000000)
    if (AutoConfiguration) MA1.Color = GetConfigColor(indicator, "MA1.Color", MA1.Color);
@@ -212,7 +245,7 @@ int onInit() {
    if (AutoConfiguration) ShowChartLegend = GetConfigBool(indicator, "ShowChartLegend", ShowChartLegend);
    // MaxBarsBack
    if (AutoConfiguration) MaxBarsBack = GetConfigInt(indicator, "MaxBarsBack", MaxBarsBack);
-   if (MaxBarsBack < -1)               return(catch("onInit(8)  invalid input parameter MaxBarsBack: "+ MaxBarsBack, ERR_INVALID_INPUT_PARAMETER));
+   if (MaxBarsBack < -1)    return(catch("onInit(8)  invalid input parameter MaxBarsBack: "+ MaxBarsBack, ERR_INVALID_INPUT_PARAMETER));
    if (MaxBarsBack == -1) MaxBarsBack = INT_MAX;
 
    // Signal.onBarCross
@@ -250,34 +283,59 @@ int onInit() {
  * @return int - error status
  */
 int onTick() {
+   // manage additional framework buffers
+   ManageIntIndicatorBuffer(MODE_MA1_POSITION, ma1.position, 0);
+   ManageIntIndicatorBuffer(MODE_MA1_TREND,    ma1.trend,    0);
+   ManageIntIndicatorBuffer(MODE_MA2_POSITION, ma2.position, 0);
+   ManageIntIndicatorBuffer(MODE_MA2_TREND,    ma2.trend,    0);
+   ManageIntIndicatorBuffer(MODE_MA3_POSITION, ma3.position, 0);
+   ManageIntIndicatorBuffer(MODE_MA3_TREND,    ma3.trend,    0);
+
    // reset buffers before performing a full recalculation
    if (!ValidBars) {
       ArrayInitialize(ma1.upperBand, EMPTY_VALUE);
       ArrayInitialize(ma1.lowerBand, EMPTY_VALUE);
+      ArrayInitialize(ma1.position,            0);
+      ArrayInitialize(ma1.trend,               0);
       ArrayInitialize(ma2.upperBand, EMPTY_VALUE);
       ArrayInitialize(ma2.lowerBand, EMPTY_VALUE);
+      ArrayInitialize(ma2.position,            0);
+      ArrayInitialize(ma2.trend,               0);
       ArrayInitialize(ma3.upperBand, EMPTY_VALUE);
       ArrayInitialize(ma3.lowerBand, EMPTY_VALUE);
+      ArrayInitialize(ma3.position,            0);
+      ArrayInitialize(ma3.trend,               0);
+      ArrayInitialize(channelPosition,         0);
+      ArrayInitialize(channelTrend,            0);
       SetIndicatorOptions();
    }
 
    // synchronize buffers with a shifted offline chart
    if (ShiftedBars > 0) {
-      ShiftDoubleIndicatorBuffer(ma1.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(ma1.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(ma2.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(ma2.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(ma3.upperBand, Bars, ShiftedBars, EMPTY_VALUE);
-      ShiftDoubleIndicatorBuffer(ma3.lowerBand, Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma1.upperBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma1.lowerBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftIntIndicatorBuffer   (ma1.position,    Bars, ShiftedBars,           0);
+      ShiftIntIndicatorBuffer   (ma1.trend,       Bars, ShiftedBars,           0);
+      ShiftDoubleIndicatorBuffer(ma2.upperBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma2.lowerBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftIntIndicatorBuffer   (ma2.position,    Bars, ShiftedBars,           0);
+      ShiftIntIndicatorBuffer   (ma2.trend,       Bars, ShiftedBars,           0);
+      ShiftDoubleIndicatorBuffer(ma3.upperBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftDoubleIndicatorBuffer(ma3.lowerBand,   Bars, ShiftedBars, EMPTY_VALUE);
+      ShiftIntIndicatorBuffer   (ma3.position,    Bars, ShiftedBars,           0);
+      ShiftIntIndicatorBuffer   (ma3.trend,       Bars, ShiftedBars,           0);
+      ShiftDoubleIndicatorBuffer(channelPosition, Bars, ShiftedBars,           0);
+      ShiftDoubleIndicatorBuffer(channelTrend,    Bars, ShiftedBars,           0);
    }
 
    // calculate start bar
-   int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods);
+   int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods), prevTrend;
    if (startbar < 0 && MaxBarsBack) return(logInfo("onTick(1)  Tick="+ Ticks, ERR_HISTORY_INSUFFICIENT));
 
    // recalculate changed bars
    for (int bar=startbar, i; bar >= 0; bar--) {
-      if (ma1.periods > 0) {
+      // MA1 channel
+      if (ma1.enabled) {
          if (ma1.method == MODE_ALMA) {
             ma1.upperBand[bar] = 0;
             ma1.lowerBand[bar] = 0;
@@ -290,9 +348,19 @@ int onTick() {
             ma1.upperBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_HIGH, bar);
             ma1.lowerBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_LOW,  bar);
          }
+
+         if      (Close[bar] > ma1.upperBand[bar]) ma1.position[bar] = +1;
+         else if (Close[bar] < ma1.lowerBand[bar]) ma1.position[bar] = -1;
+         else                                      ma1.position[bar] =  0;
+
+         prevTrend = ma1.trend[bar+1];
+         if      (Close[bar] > ma1.upperBand[bar]) ma1.trend[bar] = Max(prevTrend, 0) + 1;
+         else if (Close[bar] < ma1.lowerBand[bar]) ma1.trend[bar] = Min(prevTrend, 0) - 1;
+         else                                      ma1.trend[bar] = prevTrend + Sign(prevTrend);
       }
 
-      if (ma2.periods > 0) {
+      // MA2 channel
+      if (ma2.enabled) {
          if (ma2.method == MODE_ALMA) {
             ma2.upperBand[bar] = 0;
             ma2.lowerBand[bar] = 0;
@@ -305,9 +373,19 @@ int onTick() {
             ma2.upperBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_HIGH, bar);
             ma2.lowerBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_LOW,  bar);
          }
+
+         if      (Close[bar] > ma2.upperBand[bar]) ma2.position[bar] = +1;
+         else if (Close[bar] < ma2.lowerBand[bar]) ma2.position[bar] = -1;
+         else                                      ma2.position[bar] =  0;
+
+         prevTrend = ma2.trend[bar+1];
+         if      (Close[bar] > ma2.upperBand[bar]) ma2.trend[bar] = Max(prevTrend, 0) + 1;
+         else if (Close[bar] < ma2.lowerBand[bar]) ma2.trend[bar] = Min(prevTrend, 0) - 1;
+         else                                      ma2.trend[bar] = prevTrend + Sign(prevTrend);
       }
 
-      if (ma3.periods > 0) {
+      // MA3 channel
+      if (ma3.enabled) {
          if (ma3.method == MODE_ALMA) {
             ma3.upperBand[bar] = 0;
             ma3.lowerBand[bar] = 0;
@@ -320,7 +398,47 @@ int onTick() {
             ma3.upperBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_HIGH, bar);
             ma3.lowerBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_LOW,  bar);
          }
+
+         if      (Close[bar] > ma3.upperBand[bar]) ma3.position[bar] = +1;
+         else if (Close[bar] < ma3.lowerBand[bar]) ma3.position[bar] = -1;
+         else                                      ma3.position[bar] =  0;
+
+         prevTrend = ma3.trend[bar+1];
+         if      (Close[bar] > ma3.upperBand[bar]) ma3.trend[bar] = Max(prevTrend, 0) + 1;
+         else if (Close[bar] < ma3.lowerBand[bar]) ma3.trend[bar] = Min(prevTrend, 0) - 1;
+         else                                      ma3.trend[bar] = prevTrend + Sign(prevTrend);
       }
+
+      // overall channel position
+      bool allUp = true;
+      if (ma1.enabled) allUp = allUp && ma1.position[bar] > 0;
+      if (ma2.enabled) allUp = allUp && ma2.position[bar] > 0;
+      if (ma3.enabled) allUp = allUp && ma3.position[bar] > 0;
+
+      bool allDown = true;
+      if (ma1.enabled) allDown = allDown && ma1.position[bar] < 0;
+      if (ma2.enabled) allDown = allDown && ma2.position[bar] < 0;
+      if (ma3.enabled) allDown = allDown && ma3.position[bar] < 0;
+
+      if      (allUp)   channelPosition[bar] = +1;
+      else if (allDown) channelPosition[bar] = -1;
+      else              channelPosition[bar] =  0;
+
+      // overall channel trend
+      allUp = true;
+      if (ma1.enabled) allUp = allUp && ma1.trend[bar] > 0;
+      if (ma2.enabled) allUp = allUp && ma2.trend[bar] > 0;
+      if (ma3.enabled) allUp = allUp && ma3.trend[bar] > 0;
+
+      allDown = true;
+      if (ma1.enabled) allDown = allDown && ma1.trend[bar] < 0;
+      if (ma2.enabled) allDown = allDown && ma2.trend[bar] < 0;
+      if (ma3.enabled) allDown = allDown && ma3.trend[bar] < 0;
+
+      prevTrend = channelTrend[bar+1];
+      if      (allUp)   channelTrend[bar] = Max(prevTrend, 0) + 1;
+      else if (allDown) channelTrend[bar] = Min(prevTrend, 0) - 1;
+      else              channelTrend[bar] = prevTrend + Sign(prevTrend);
    }
 
    if (__isChart && !__isSuperContext) {
@@ -328,8 +446,8 @@ int onTick() {
 
       // monitor signals
       if (Signal.onBarCross) /*&&*/ if (IsBarOpen()) {
-         if      (false) onCross(D_LONG);
-         else if (false) onCross(D_SHORT);
+         if      (channelTrend[1] ==  1) onCross(D_LONG);
+         else if (channelTrend[1] == -1) onCross(D_SHORT);
       }
    }
    return(last_error);
@@ -453,24 +571,32 @@ bool SetIndicatorOptions(bool redraw = false) {
    SetIndexLabel (MODE_MA3_UPPER, MA3.Method +"("+ MA3.Periods +") upper band");
    SetIndexLabel (MODE_MA3_LOWER, MA3.Method +"("+ MA3.Periods +") lower band");
 
-   if (!ma1.periods) {
+   if (!ma1.enabled) {
       SetIndexStyle(MODE_MA1_UPPER, DRAW_NONE);
       SetIndexStyle(MODE_MA1_LOWER, DRAW_NONE);
       SetIndexLabel(MODE_MA1_UPPER, NULL);
       SetIndexLabel(MODE_MA1_LOWER, NULL);
    }
-   if (!ma2.periods) {
+   if (!ma2.enabled) {
       SetIndexStyle(MODE_MA2_UPPER, DRAW_NONE);
       SetIndexStyle(MODE_MA2_LOWER, DRAW_NONE);
       SetIndexLabel(MODE_MA2_UPPER, NULL);
       SetIndexLabel(MODE_MA2_LOWER, NULL);
    }
-   if (!ma3.periods) {
+   if (!ma3.enabled) {
       SetIndexStyle(MODE_MA3_UPPER, DRAW_NONE);
       SetIndexStyle(MODE_MA3_LOWER, DRAW_NONE);
       SetIndexLabel(MODE_MA3_UPPER, NULL);
       SetIndexLabel(MODE_MA3_LOWER, NULL);
    }
+
+   SetIndexBuffer(MODE_POSITION, channelPosition);
+   SetIndexStyle (MODE_POSITION, DRAW_NONE);
+   SetIndexLabel (MODE_POSITION, NULL);
+
+   SetIndexBuffer(MODE_TREND, channelTrend);
+   SetIndexStyle (MODE_TREND, DRAW_NONE);
+   SetIndexLabel (MODE_TREND, "MA Channel trend");
 
    if (redraw) WindowRedraw();
    return(!catch("SetIndicatorOptions(1)"));
@@ -486,26 +612,26 @@ string GetChannelDescription() {
    string sameMethods = "", differentMethods = "";
    bool allSameMethod = true;
 
-   if (ma1.periods > 0) {
+   if (ma1.enabled) {
       sameMethods      = MA1.Method +"("+ MA1.Periods;
       differentMethods = differentMethods +","+ MA1.Method +"("+ MA1.Periods +")";
    }
-   if (ma2.periods > 0) {
+   if (ma2.enabled) {
       sameMethods      = sameMethods +","+ MA2.Periods;
       differentMethods = differentMethods +","+ MA2.Method +"("+ MA2.Periods +")";
 
-      if (ma1.periods > 0) {
+      if (ma1.enabled) {
          allSameMethod = (ma1.method == ma2.method);
       }
    }
-   if (ma3.periods > 0) {
+   if (ma3.enabled) {
       sameMethods      = sameMethods +","+ MA3.Periods;
       differentMethods = differentMethods +","+ MA3.Method +"("+ MA3.Periods +")";
 
-      if (ma1.periods > 0) {
+      if (ma1.enabled) {
          allSameMethod = (ma1.method == ma3.method);
       }
-      if (ma2.periods > 0) {
+      if (ma2.enabled) {
          allSameMethod = (ma2.method == ma3.method);
       }
    }

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -42,31 +42,37 @@ int __DeinitFlags[];
 
 ////////////////////////////////////////////////////// Configuration ////////////////////////////////////////////////////////
 
-extern string ___a__________________________ = "=== MA definitions ===";
-extern string MA1.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA1.Periods                    = 100;
-extern int    MA1.ChannelWidth.Pct           = 100;                     // percent of High/Low range
-extern color  MA1.Color                      = Magenta;
+extern string ___a__________________________  = "=== MA definitions ===";
+extern string MA1.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA1.Periods                     = 100;
+extern int    MA1.ChannelWidth.Pct            = 100;                     // percent of High/Low range
+extern color  MA1.Color                       = Magenta;
 
-extern string MA2.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA2.Periods                    = 0;
-extern int    MA2.ChannelWidth.Pct           = 100;
-extern color  MA2.Color                      = Blue;
+extern string MA2.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA2.Periods                     = 0;
+extern int    MA2.ChannelWidth.Pct            = 100;
+extern color  MA2.Color                       = Blue;
 
-extern string MA3.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA3.Periods                    = 0;
-extern int    MA3.ChannelWidth.Pct           = 100;
-extern color  MA3.Color                      = Red;
+extern string MA3.Method                      = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA3.Periods                     = 0;
+extern int    MA3.ChannelWidth.Pct            = 100;
+extern color  MA3.Color                       = Red;
 
-extern string ___b__________________________ = "=== Display options ===";
-extern bool   ShowChartLegend                = true;
-extern int    MaxBarsBack                    = 10000;                   // max. values to calculate (-1: all available)
+extern string ___b__________________________  = "=== Display options ===";
+extern bool   ShowChartLegend                 = true;
+extern int    MaxBarsBack                     = 10000;                   // max. values to calculate (-1: all available)
 
-extern string ___c__________________________ = "=== Signaling ===";
-extern bool   Signal.onBarCross              = false;                   // on BarClose crossing the most outer channel
-extern string Signal.onBarCross.Types        = "sound* | alert | mail | telegram";
-extern string Signal.Sound.Up                = "Signal Up.wav";
-extern string Signal.Sound.Down              = "Signal Down.wav";
+extern string ___c__________________________  = "=== Signaling ===";
+extern bool   Signal.onPositionChange         = false;                   // on BarClose crossing the position boundary
+extern string Signal.onPosition.Types         = "sound* | alert | mail | telegram";
+extern string Signal.onPosition.Sound.Above   = "Signal Up.wav";
+extern string Signal.onPosition.Sound.Below   = "Signal Down.wav";
+extern string Signal.onPosition.Sound.Between = "Signal Between.wav";
+
+extern bool   Signal.onTrendChange            = false;                   // on BarClose causing a trend change
+extern string Signal.onTrend.Types            = "sound* | alert | mail | telegram";
+extern string Signal.onTrend.Sound.Up         = "Signal Up.wav";
+extern string Signal.onTrend.Sound.Down       = "Signal Down.wav";
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -147,10 +153,15 @@ string legendLabel = "";
 string legendInfo = "";
 color  legendColor;
 
-bool   signal.sound;
-bool   signal.alert;
-bool   signal.mail;
-bool   signal.telegram;
+bool   signal.onPosition.sound;
+bool   signal.onPosition.alert;
+bool   signal.onPosition.mail;
+bool   signal.onPosition.telegram;
+
+bool   signal.onTrend.sound;
+bool   signal.onTrend.alert;
+bool   signal.onTrend.mail;
+bool   signal.onTrend.telegram;
 
 #define D_LONG  TRADE_DIRECTION_LONG                     // signal direction types
 #define D_SHORT TRADE_DIRECTION_SHORT                    //
@@ -264,20 +275,36 @@ int onInit() {
    if (MaxBarsBack < -1)            return(catch("onInit(11)  invalid input parameter MaxBarsBack: "+ MaxBarsBack, ERR_INVALID_INPUT_PARAMETER));
    if (MaxBarsBack == -1) MaxBarsBack = INT_MAX;
 
-   // Signal.onBarCross
-   string signalId = "Signal.onBarCross";
+   // Signal.onPositionChange
+   string signalId = "Signal.onPositionChange";
    legendInfo = "";
-   if (!ConfigureSignals(signalId, AutoConfiguration, Signal.onBarCross)) return(last_error);
-   if (Signal.onBarCross) {
-      if (!ConfigureSignalTypes(signalId, Signal.onBarCross.Types, AutoConfiguration, signal.sound, signal.alert, signal.mail, signal.telegram)) {
-         return(catch("onInit(12)  invalid input parameter Signal.onBarCross.Types: "+ DoubleQuoteStr(Signal.onBarCross.Types), ERR_INVALID_INPUT_PARAMETER));
+   if (!ConfigureSignals(signalId, AutoConfiguration, Signal.onPositionChange)) return(last_error);
+   if (Signal.onPositionChange) {
+      if (!ConfigureSignalTypes(signalId, Signal.onPosition.Types, AutoConfiguration, signal.onPosition.sound, signal.onPosition.alert, signal.onPosition.mail, signal.onPosition.telegram)) {
+         return(catch("onInit(12)  invalid input parameter Signal.onPosition.Types: "+ DoubleQuoteStr(Signal.onPosition.Types), ERR_INVALID_INPUT_PARAMETER));
       }
-      Signal.onBarCross = (signal.sound || signal.alert || signal.mail || signal.telegram);
-      if (Signal.onBarCross) legendInfo = "("+ StrLeft(ifString(signal.sound, "sound,", "") + ifString(signal.alert, "alert,", "") + ifString(signal.mail, "mail,", "") + ifString(signal.telegram, "tgm,", ""), -1) +")";
+      Signal.onPositionChange = (signal.onPosition.sound || signal.onPosition.alert || signal.onPosition.mail || signal.onPosition.telegram);
+      if (Signal.onPositionChange) legendInfo = "("+ StrLeft(ifString(signal.onPosition.sound, "sound,", "") + ifString(signal.onPosition.alert, "alert,", "") + ifString(signal.onPosition.mail, "mail,", "") + ifString(signal.onPosition.telegram, "tgm,", ""), -1) +")";
    }
-   // Signal.Sound.*
-   if (AutoConfiguration) Signal.Sound.Up   = GetConfigString(indicator, "Signal.Sound.Up",   Signal.Sound.Up);
-   if (AutoConfiguration) Signal.Sound.Down = GetConfigString(indicator, "Signal.Sound.Down", Signal.Sound.Down);
+
+   // Signal.onTrendChange
+   signalId = "Signal.onTrendChange";
+   if (!ConfigureSignals(signalId, AutoConfiguration, Signal.onTrendChange)) return(last_error);
+   if (Signal.onTrendChange) {
+      if (!ConfigureSignalTypes(signalId, Signal.onTrend.Types, AutoConfiguration, signal.onTrend.sound, signal.onTrend.alert, signal.onTrend.mail, signal.onTrend.telegram)) {
+         return(catch("onInit(13)  invalid input parameter Signal.onTrend.Types: "+ DoubleQuoteStr(Signal.onTrend.Types), ERR_INVALID_INPUT_PARAMETER));
+      }
+      Signal.onTrendChange = (signal.onTrend.sound || signal.onTrend.alert || signal.onTrend.mail || signal.onTrend.telegram);
+      if (Signal.onTrendChange) legendInfo = StrTrimLeft(legendInfo +" (") + StrLeft(ifString(signal.onTrend.sound, "sound,", "") + ifString(signal.onTrend.alert, "alert,", "") + ifString(signal.onTrend.mail, "mail,", "") + ifString(signal.onTrend.telegram, "tgm,", ""), -1) +")";
+   }
+
+   // sounds
+   if (AutoConfiguration) Signal.onPosition.Sound.Above   = GetConfigString(indicator, "Signal.onPosition.Sound.Above",   Signal.onPosition.Sound.Above);
+   if (AutoConfiguration) Signal.onPosition.Sound.Below   = GetConfigString(indicator, "Signal.onPosition.Sound.Below",   Signal.onPosition.Sound.Below);
+   if (AutoConfiguration) Signal.onPosition.Sound.Between = GetConfigString(indicator, "Signal.onPosition.Sound.Between", Signal.onPosition.Sound.Between);
+
+   if (AutoConfiguration) Signal.onTrend.Sound.Up   = GetConfigString(indicator, "Signal.onTrend.Sound.Up",   Signal.onTrend.Sound.Up);
+   if (AutoConfiguration) Signal.onTrend.Sound.Down = GetConfigString(indicator, "Signal.onTrend.Sound.Down", Signal.onTrend.Sound.Down);
 
    // calculate ALMA bar weights
    double almaOffset=0.85, almaSigma=6.0;
@@ -289,7 +316,7 @@ int onInit() {
    SetIndicatorOptions();
    if (ShowChartLegend) legendLabel = CreateChartLegend();
 
-   return(catch("onInit(13)"));
+   return(catch("onInit(14)"));
 }
 
 
@@ -481,9 +508,18 @@ int onTick() {
       if (ShowChartLegend) UpdateChartLegend();
 
       // monitor signals
-      if (Signal.onBarCross) /*&&*/ if (IsBarOpen()) {
-         if      (channelTrend[1] ==  1) onCross(D_LONG);
-         else if (channelTrend[1] == -1) onCross(D_SHORT);
+      if (Signal.onPositionChange || Signal.onTrendChange) {
+         if (IsBarOpen()) {
+            if (Signal.onPositionChange) {
+               if (channelPosition[1] != channelPosition[2]) {
+                  onPositionChange(channelPosition[1]);
+               }
+            }
+            if (Signal.onTrendChange) {
+               if      (channelTrend[1] ==  1) onTrendChange(D_LONG);
+               else if (channelTrend[1] == -1) onTrendChange(D_SHORT);
+            }
+         }
       }
    }
    return(last_error);
@@ -491,25 +527,26 @@ int onTick() {
 
 
 /**
- * Event handler signaling channel crossings.
+ * Event handler signaling a price change relative to the channel position.
  *
- * @param  int direction - crossing direction: D_LONG | D_SHORT
+ * @param  int position - new position: -1..0..+1
  *
  * @return bool - success status
  */
-bool onCross(int direction) {
-   if (direction!=D_LONG && direction!=D_SHORT) return(!catch("onCross(1)  invalid parameter direction: "+ direction, ERR_INVALID_PARAMETER));
-   if (!Signal.onBarCross) return(false);
-   if (ChangedBars > 2)    return(false);
+bool onPositionChange(int position) {
+   if (Abs(position) > 1)        return(!catch("onPositionChange(1)  invalid parameter position: "+ position, ERR_INVALID_PARAMETER));
+   if (!Signal.onPositionChange) return(false);
+   if (ChangedBars > 2)          return(false);
+
+   static string sPositions[] = { "below", "in", "above" };
 
    // skip the signal if it was already handled elsewhere
    string sPeriod   = PeriodDescription();
-   string eventName = "rsf::"+ StdSymbol() +","+ sPeriod +"."+ indicatorName +".onCross("+ direction +")."+ TimeToStr(Time[0]), propertyName = "";
-   string message1  = "bar close "+ ifString(direction==D_LONG, "above ", "below ") + indicatorName;
+   string eventName = "rsf."+ StdSymbol() +","+ sPeriod +"."+ indicatorName +".onPositionChange("+ position +")."+ TimeToStr(Time[0]), propertyName = "";
+   string message1  = "bar close "+ sPositions[position+1] +" "+ indicatorName;
    string message2  = Symbol() +","+ sPeriod +": "+ message1;
-   string localTime = TimeToStr(TimeLocalEx("onCross(2)"), TIME_MINUTES|TIME_SECONDS);
-   string accountAlias = GetAccountAlias();
-
+   string localTime = TimeToStr(TimeLocalEx("onPositionChange(2)"), TIME_MINUTES|TIME_SECONDS);
+   string alias     = GetAccountAlias();
    int hWndTerminal = GetTerminalMainWindow(), hWndDesktop = GetDesktopWindow();
    bool eventAction;
 
@@ -521,22 +558,26 @@ bool onCross(int direction) {
          eventAction = !GetWindowPropertyA(hWndTerminal, propertyName);
          SetWindowPropertyA(hWndTerminal, propertyName, 1);
       }
-      if (eventAction) logInfo("onCross(3)  "+ message1);
+      if (eventAction) logInfo("onPositionChange(3)  "+ message1);
    }
 
    // sound: once per system
-   if (signal.sound) {
+   if (signal.onPosition.sound) {
       eventAction = true;
       if (!__isTesting) {
          propertyName = eventName +"|sound";
          eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
          SetWindowPropertyA(hWndDesktop, propertyName, 1);
       }
-      if (eventAction) PlaySoundEx(ifString(direction==D_LONG, Signal.Sound.Up, Signal.Sound.Down));
+      if (eventAction) {
+         if      (position > 0) PlaySoundEx(Signal.onPosition.Sound.Above);
+         else if (position < 0) PlaySoundEx(Signal.onPosition.Sound.Below);
+         else                   PlaySoundEx(Signal.onPosition.Sound.Between);
+      }
    }
 
    // alert: once per terminal
-   if (signal.alert) {
+   if (signal.onPosition.alert) {
       eventAction = true;
       if (!__isTesting) {
          propertyName = eventName +"|alert";
@@ -547,27 +588,109 @@ bool onCross(int direction) {
    }
 
    // mail: once per system
-   if (signal.mail) {
+   if (signal.onPosition.mail) {
       eventAction = true;
       if (!__isTesting) {
          propertyName = eventName +"|mail";
          eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
          SetWindowPropertyA(hWndDesktop, propertyName, 1);
       }
-      if (eventAction) SendEmail("", "", message2, message2 + NL +"("+ localTime +", "+ accountAlias +")");
+      if (eventAction) SendEmail("", "", message2, message2 + NL +"("+ localTime +", "+ alias +")");
    }
 
    // telegram: once per system
-   if (signal.telegram) {
+   if (signal.onPosition.telegram) {
       eventAction = true;
       if (!__isTesting) {
          propertyName = eventName +"|telegram";
          eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
          SetWindowPropertyA(hWndDesktop, propertyName, 1);
       }
-      if (eventAction) SendTelegramMessage("signal", message2 + NL +"("+ localTime +", "+ accountAlias +")");
+      if (eventAction) SendTelegramMessage("signal", message2 + NL +"("+ localTime +", "+ alias +")");
    }
-   return(!catch("onCross(4)"));
+   return(!catch("onPositionChange(4)"));
+}
+
+
+/**
+ * Event handler signaling a trend change.
+ *
+ * @param  int direction - trend direction: D_LONG | D_SHORT
+ *
+ * @return bool - success status
+ */
+bool onTrendChange(int direction) {
+   if (direction!=D_LONG && direction!=D_SHORT) return(!catch("onTrendChange(1)  invalid parameter direction: "+ direction, ERR_INVALID_PARAMETER));
+   if (!Signal.onTrendChange)                   return(false);
+   if (ChangedBars > 2)                         return(false);
+
+   static string sTrendDirections[] = { "", "up", "down" };
+
+   // skip the signal if it was already handled elsewhere
+   string sPeriod   = PeriodDescription();
+   string eventName = "rsf."+ StdSymbol() +","+ sPeriod +"."+ indicatorName +".onTrendChange("+ direction +")."+ TimeToStr(Time[0]), propertyName = "";
+   string message1  = "bar close on "+ indicatorName +" changed to "+ sTrendDirections[direction] +" trend";
+   string message2  = Symbol() +","+ sPeriod +": "+ message1;
+   string localTime = TimeToStr(TimeLocalEx("onTrendChange(2)"), TIME_MINUTES|TIME_SECONDS);
+   string alias     = GetAccountAlias();
+   int hWndTerminal = GetTerminalMainWindow(), hWndDesktop = GetDesktopWindow();
+   bool eventAction;
+
+   // log: once per terminal
+   if (IsLogInfo()) {
+      eventAction = true;
+      if (!__isTesting) {
+         propertyName = eventName +"|log";
+         eventAction = !GetWindowPropertyA(hWndTerminal, propertyName);
+         SetWindowPropertyA(hWndTerminal, propertyName, 1);
+      }
+      if (eventAction) logInfo("onTrendChange(3)  "+ message1);
+   }
+
+   // sound: once per system
+   if (signal.onTrend.sound) {
+      eventAction = true;
+      if (!__isTesting) {
+         propertyName = eventName +"|sound";
+         eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
+         SetWindowPropertyA(hWndDesktop, propertyName, 1);
+      }
+      if (eventAction) PlaySoundEx(ifString(direction==D_LONG, Signal.onTrend.Sound.Up, Signal.onTrend.Sound.Down));
+   }
+
+   // alert: once per terminal
+   if (signal.onTrend.alert) {
+      eventAction = true;
+      if (!__isTesting) {
+         propertyName = eventName +"|alert";
+         eventAction = !GetWindowPropertyA(hWndTerminal, propertyName);
+         SetWindowPropertyA(hWndTerminal, propertyName, 1);
+      }
+      if (eventAction) Alert(message2);
+   }
+
+   // mail: once per system
+   if (signal.onTrend.mail) {
+      eventAction = true;
+      if (!__isTesting) {
+         propertyName = eventName +"|mail";
+         eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
+         SetWindowPropertyA(hWndDesktop, propertyName, 1);
+      }
+      if (eventAction) SendEmail("", "", message2, message2 + NL +"("+ localTime +", "+ alias +")");
+   }
+
+   // telegram: once per system
+   if (signal.onTrend.telegram) {
+      eventAction = true;
+      if (!__isTesting) {
+         propertyName = eventName +"|telegram";
+         eventAction = !GetWindowPropertyA(hWndDesktop, propertyName);
+         SetWindowPropertyA(hWndDesktop, propertyName, 1);
+      }
+      if (eventAction) SendTelegramMessage("signal", message2 + NL +"("+ localTime +", "+ alias +")");
+   }
+   return(!catch("onTrendChange(4)"));
 }
 
 
@@ -744,28 +867,34 @@ string GetChannelDescription() {
  */
 string InputsToStr() {
    return(StringConcatenate(
-      "MA1.Method=",              DoubleQuoteStr(MA1.Method),              ";"+ NL,
-      "MA1.Periods=",             MA1.Periods,                             ";"+ NL,
-      "MA1.ChannelWidth.Pct=",    MA1.ChannelWidth.Pct,                    ";"+ NL,
-      "MA1.Color=",               ColorToStr(MA1.Color),                   ";"+ NL,
+      "MA1.Method=",                      DoubleQuoteStr(MA1.Method)                      +";"+ NL,
+      "MA1.Periods=",                     MA1.Periods                                     +";"+ NL,
+      "MA1.ChannelWidth.Pct=",            MA1.ChannelWidth.Pct                            +";"+ NL,
+      "MA1.Color=",                       ColorToStr(MA1.Color)                           +";"+ NL,
 
-      "MA2.Method=",              DoubleQuoteStr(MA2.Method),              ";"+ NL,
-      "MA2.Periods=",             MA2.Periods,                             ";"+ NL,
-      "MA2.ChannelWidth.Pct=",    MA2.ChannelWidth.Pct,                    ";"+ NL,
-      "MA2.Color=",               ColorToStr(MA2.Color),                   ";"+ NL,
+      "MA2.Method=",                      DoubleQuoteStr(MA2.Method)                      +";"+ NL,
+      "MA2.Periods=",                     MA2.Periods                                     +";"+ NL,
+      "MA2.ChannelWidth.Pct=",            MA2.ChannelWidth.Pct                            +";"+ NL,
+      "MA2.Color=",                       ColorToStr(MA2.Color)                           +";"+ NL,
 
-      "MA3.Method=",              DoubleQuoteStr(MA3.Method),              ";"+ NL,
-      "MA3.Periods=",             MA3.Periods,                             ";"+ NL,
-      "MA3.ChannelWidth.Pct=",    MA3.ChannelWidth.Pct,                    ";"+ NL,
-      "MA3.Color=",               ColorToStr(MA3.Color),                   ";"+ NL,
+      "MA3.Method=",                      DoubleQuoteStr(MA3.Method)                      +";"+ NL,
+      "MA3.Periods=",                     MA3.Periods                                     +";"+ NL,
+      "MA3.ChannelWidth.Pct=",            MA3.ChannelWidth.Pct                            +";"+ NL,
+      "MA3.Color=",                       ColorToStr(MA3.Color)                           +";"+ NL,
 
-      "ShowChartLegend=",         BoolToStr(ShowChartLegend),              ";"+ NL,
-      "MaxBarsBack=",             MaxBarsBack,                             ";"+ NL,
+      "ShowChartLegend=",                 BoolToStr(ShowChartLegend)                      +";"+ NL,
+      "MaxBarsBack=",                     MaxBarsBack                                     +";"+ NL,
 
-      "Signal.onBarCross=",       BoolToStr(Signal.onBarCross),            ";"+ NL,
-      "Signal.onBarCross.Types=", DoubleQuoteStr(Signal.onBarCross.Types), ";"+ NL,
-      "Signal.Sound.Up=",         DoubleQuoteStr(Signal.Sound.Up),         ";"+ NL,
-      "Signal.Sound.Down=",       DoubleQuoteStr(Signal.Sound.Down),       ";"+ NL
+      "Signal.onPositionChange=",         BoolToStr(Signal.onPositionChange)              +";"+ NL,
+      "Signal.onPosition.Types=",         DoubleQuoteStr(Signal.onPosition.Types)         +";"+ NL,
+      "Signal.onPosition.Sound.Above=",   DoubleQuoteStr(Signal.onPosition.Sound.Above)   +";"+ NL,
+      "Signal.onPosition.Sound.Below=",   DoubleQuoteStr(Signal.onPosition.Sound.Below)   +";"+ NL,
+      "Signal.onPosition.Sound.Between=", DoubleQuoteStr(Signal.onPosition.Sound.Between) +";"+ NL,
+
+      "Signal.onTrendChange=",            BoolToStr(Signal.onTrendChange)                 +";"+ NL,
+      "Signal.onTrend.Types=",            DoubleQuoteStr(Signal.onTrend.Types)            +";"+ NL,
+      "Signal.onTrend.Sound..Up=",        DoubleQuoteStr(Signal.onTrend.Sound.Up)         +";"+ NL,
+      "Signal.onTrend.Sound..Down=",      DoubleQuoteStr(Signal.onTrend.Sound.Down)       +";"+ NL
    ));
 
    // suppress compiler warnings

--- a/mql40/indicators/MA Channel.mq4
+++ b/mql40/indicators/MA Channel.mq4
@@ -35,10 +35,6 @@
  *
  *  • ALMA calculation:
  *    @see http://web.archive.org/web/20180307031850/http://www.arnaudlegoux.com/
- *
- *
- * TODO:
- *  - add input "Channel.Width" = 100% (percent of High/Low range)
  */
 #include <rsf/stddefines.mqh>
 int   __InitFlags[];
@@ -47,17 +43,20 @@ int __DeinitFlags[];
 ////////////////////////////////////////////////////// Configuration ////////////////////////////////////////////////////////
 
 extern string ___a__________________________ = "=== MA definitions ===";
-extern string MA1.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA1.Periods = 100;
-extern color  MA1.Color   = Magenta;
+extern string MA1.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA1.Periods                    = 100;
+extern int    MA1.ChannelWidth.Pct           = 100;                     // percent of High/Low range
+extern color  MA1.Color                      = Magenta;
 
-extern string MA2.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA2.Periods = 0;
-extern color  MA2.Color   = Blue;
+extern string MA2.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA2.Periods                    = 0;
+extern int    MA2.ChannelWidth.Pct           = 100;
+extern color  MA2.Color                      = Blue;
 
-extern string MA3.Method  = "SMA* | LWMA | EMA | SMMA | ALMA";
-extern int    MA3.Periods = 0;
-extern color  MA3.Color   = Red;
+extern string MA3.Method                     = "SMA* | LWMA | EMA | SMMA | ALMA";
+extern int    MA3.Periods                    = 0;
+extern int    MA3.ChannelWidth.Pct           = 100;
+extern color  MA3.Color                      = Red;
 
 extern string ___b__________________________ = "=== Display options ===";
 extern bool   ShowChartLegend                = true;
@@ -165,16 +164,17 @@ int onInit() {
    // input validation
    string indicator = WindowExpertName();
 
-   // MA1.Periods (must be checked before MA.Method)
+   // MA1.Periods (enables/disables MA1 and must be checked first)
    ma1.enabled = false;
    if (AutoConfiguration) MA1.Periods = GetConfigInt(indicator, "MA1.Periods", MA1.Periods);
-   if (MA1.Periods < 0)     return(catch("onInit(1)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA1.Periods < 0)             return(catch("onInit(1)  invalid input parameter MA1.Periods: "+ MA1.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma1.periods = MA1.Periods;
-   // MA1.Method
    if (!ma1.periods) {
       MA1.Method = "";
+      MA1.ChannelWidth.Pct = 100;
    }
    else {
+      // MA1.Method
       if (AutoConfiguration) MA1.Method = GetConfigString(indicator, "MA1.Method", MA1.Method);
       string sValues[], sValue = MA1.Method;
       if (Explode(sValue, "*", sValues, 2) > 1) {
@@ -182,21 +182,25 @@ int onInit() {
          sValue = sValues[size-1];
       }
       ma1.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-      if (ma1.method == -1) return(catch("onInit(2)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
+      if (ma1.method == -1)         return(catch("onInit(2)  invalid input parameter MA1.Method: "+ DoubleQuoteStr(MA1.Method), ERR_INVALID_INPUT_PARAMETER));
       MA1.Method = MaMethodDescription(ma1.method);
       ma1.enabled = true;
+      // MA1.ChannelWidth.Pct
+      if (AutoConfiguration) MA1.ChannelWidth.Pct = GetConfigInt(indicator, "MA1.ChannelWidth.Pct", MA1.ChannelWidth.Pct);
+      if (MA1.ChannelWidth.Pct < 1) return(catch("onInit(3)  invalid input parameter MA1.ChannelWidth.Pct: "+ MA1.ChannelWidth.Pct +" (must be > 0)", ERR_INVALID_INPUT_PARAMETER));
    }
 
-   // MA2.Periods
+   // MA2.Periods (enables/disables MA2 and must be checked first)
    ma2.enabled = false;
    if (AutoConfiguration) MA2.Periods = GetConfigInt(indicator, "MA2.Periods", MA2.Periods);
-   if (MA2.Periods < 0)     return(catch("onInit(3)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA2.Periods < 0)             return(catch("onInit(4)  invalid input parameter MA2.Periods: "+ MA2.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma2.periods = MA2.Periods;
-   // MA2.Method
    if (!ma2.periods) {
       MA2.Method = "";
+      MA2.ChannelWidth.Pct = 100;
    }
    else {
+      // MA2.Method
       if (AutoConfiguration) MA2.Method = GetConfigString(indicator, "MA2.Method", MA2.Method);
       sValue = MA2.Method;
       if (Explode(sValue, "*", sValues, 2) > 1) {
@@ -204,21 +208,25 @@ int onInit() {
          sValue = sValues[size-1];
       }
       ma2.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-      if (ma2.method == -1) return(catch("onInit(4)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
+      if (ma2.method == -1)         return(catch("onInit(5)  invalid input parameter MA2.Method: "+ DoubleQuoteStr(MA2.Method), ERR_INVALID_INPUT_PARAMETER));
       MA2.Method = MaMethodDescription(ma2.method);
       ma2.enabled = true;
+      // MA2.ChannelWidth.Pct
+      if (AutoConfiguration) MA2.ChannelWidth.Pct = GetConfigInt(indicator, "MA2.ChannelWidth.Pct", MA2.ChannelWidth.Pct);
+      if (MA2.ChannelWidth.Pct < 1) return(catch("onInit(6)  invalid input parameter MA2.ChannelWidth.Pct: "+ MA2.ChannelWidth.Pct +" (must be > 0)", ERR_INVALID_INPUT_PARAMETER));
    }
 
-   // MA3.Periods
+   // MA3.Periods (enables/disables MA3 and must be checked first)
    ma3.enabled = false;
    if (AutoConfiguration) MA3.Periods = GetConfigInt(indicator, "MA3.Periods", MA3.Periods);
-   if (MA3.Periods < 0)     return(catch("onInit(5)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
+   if (MA3.Periods < 0)             return(catch("onInit(7)  invalid input parameter MA3.Periods: "+ MA3.Periods +" (must be >= zero)", ERR_INVALID_INPUT_PARAMETER));
    ma3.periods = MA3.Periods;
-   // MA3.Method
    if (!ma3.periods) {
       MA3.Method = "";
+      MA3.ChannelWidth.Pct = 100;
    }
    else {
+      // MA3.Method
       if (AutoConfiguration) MA3.Method = GetConfigString(indicator, "MA3.Method", MA3.Method);
       sValue = MA3.Method;
       if (Explode(sValue, "*", sValues, 2) > 1) {
@@ -226,12 +234,16 @@ int onInit() {
          sValue = sValues[size-1];
       }
       ma3.method = StrToMaMethod(sValue, F_PARTIAL_ID|F_ERR_INVALID_PARAMETER);
-      if (ma3.method == -1) return(catch("onInit(6)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
+      if (ma3.method == -1)         return(catch("onInit(8)  invalid input parameter MA3.Method: "+ DoubleQuoteStr(MA3.Method), ERR_INVALID_INPUT_PARAMETER));
       MA3.Method = MaMethodDescription(ma3.method);
       ma3.enabled = true;
+      // MA3.ChannelWidth.Pct
+      if (AutoConfiguration) MA3.ChannelWidth.Pct = GetConfigInt(indicator, "MA3.ChannelWidth.Pct", MA3.ChannelWidth.Pct);
+      if (MA3.ChannelWidth.Pct < 1) return(catch("onInit(9)  invalid input parameter MA3.ChannelWidth.Pct: "+ MA3.ChannelWidth.Pct +" (must be > 0)", ERR_INVALID_INPUT_PARAMETER));
    }
+
    maxMaPeriods = Max(ma1.periods, ma2.periods, ma3.periods);
-   if (!maxMaPeriods)       return(catch("onInit(7)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
+   if (!maxMaPeriods)               return(catch("onInit(10)  invalid MA definitions: at least one MA needs a period value", ERR_INVALID_INPUT_PARAMETER));
 
    // colors: after deserialization the terminal may turn CLR_NONE (0xFFFFFFFF) into Black (0xFF000000)
    if (AutoConfiguration) MA1.Color = GetConfigColor(indicator, "MA1.Color", MA1.Color);
@@ -245,7 +257,7 @@ int onInit() {
    if (AutoConfiguration) ShowChartLegend = GetConfigBool(indicator, "ShowChartLegend", ShowChartLegend);
    // MaxBarsBack
    if (AutoConfiguration) MaxBarsBack = GetConfigInt(indicator, "MaxBarsBack", MaxBarsBack);
-   if (MaxBarsBack < -1)    return(catch("onInit(8)  invalid input parameter MaxBarsBack: "+ MaxBarsBack, ERR_INVALID_INPUT_PARAMETER));
+   if (MaxBarsBack < -1)            return(catch("onInit(11)  invalid input parameter MaxBarsBack: "+ MaxBarsBack, ERR_INVALID_INPUT_PARAMETER));
    if (MaxBarsBack == -1) MaxBarsBack = INT_MAX;
 
    // Signal.onBarCross
@@ -254,7 +266,7 @@ int onInit() {
    if (!ConfigureSignals(signalId, AutoConfiguration, Signal.onBarCross)) return(last_error);
    if (Signal.onBarCross) {
       if (!ConfigureSignalTypes(signalId, Signal.onBarCross.Types, AutoConfiguration, signal.sound, signal.alert, signal.mail, signal.telegram)) {
-         return(catch("onInit(9)  invalid input parameter Signal.onBarCross.Types: "+ DoubleQuoteStr(Signal.onBarCross.Types), ERR_INVALID_INPUT_PARAMETER));
+         return(catch("onInit(12)  invalid input parameter Signal.onBarCross.Types: "+ DoubleQuoteStr(Signal.onBarCross.Types), ERR_INVALID_INPUT_PARAMETER));
       }
       Signal.onBarCross = (signal.sound || signal.alert || signal.mail || signal.telegram);
       if (Signal.onBarCross) legendInfo = "("+ StrLeft(ifString(signal.sound, "sound,", "") + ifString(signal.alert, "alert,", "") + ifString(signal.mail, "mail,", "") + ifString(signal.telegram, "tgm,", ""), -1) +")";
@@ -273,7 +285,7 @@ int onInit() {
    if (ShowChartLegend) legendLabel = CreateChartLegend();
 
    SetIndicatorOptions();
-   return(catch("onInit(10)"));
+   return(catch("onInit(13)"));
 }
 
 
@@ -328,6 +340,8 @@ int onTick() {
       ShiftDoubleIndicatorBuffer(channelTrend,    Bars, ShiftedBars,           0);
    }
 
+   double range, extension;
+
    // calculate start bar
    int startbar = Min(MaxBarsBack-1, ChangedBars-1, Bars-maxMaPeriods), prevTrend;
    if (startbar < 0 && MaxBarsBack) return(logInfo("onTick(1)  Tick="+ Ticks, ERR_HISTORY_INSUFFICIENT));
@@ -347,6 +361,12 @@ int onTick() {
          else {
             ma1.upperBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_HIGH, bar);
             ma1.lowerBand[bar] = iMA(NULL, NULL, ma1.periods, 0, ma1.method, PRICE_LOW,  bar);
+         }
+         if (MA1.ChannelWidth.Pct != 100) {
+            range     = ma1.upperBand[bar] - ma1.lowerBand[bar];
+            extension = (MA1.ChannelWidth.Pct - 100) / 100.0 / 2;
+            ma1.upperBand[bar] += extension * range;
+            ma1.lowerBand[bar] -= extension * range;
          }
 
          if      (Close[bar] > ma1.upperBand[bar]) ma1.position[bar] = +1;
@@ -373,6 +393,12 @@ int onTick() {
             ma2.upperBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_HIGH, bar);
             ma2.lowerBand[bar] = iMA(NULL, NULL, ma2.periods, 0, ma2.method, PRICE_LOW,  bar);
          }
+         if (MA2.ChannelWidth.Pct != 100) {
+            range     = ma2.upperBand[bar] - ma2.lowerBand[bar];
+            extension = (MA2.ChannelWidth.Pct - 100) / 100.0 / 2;
+            ma2.upperBand[bar] += extension * range;
+            ma2.lowerBand[bar] -= extension * range;
+         }
 
          if      (Close[bar] > ma2.upperBand[bar]) ma2.position[bar] = +1;
          else if (Close[bar] < ma2.lowerBand[bar]) ma2.position[bar] = -1;
@@ -397,6 +423,12 @@ int onTick() {
          else {
             ma3.upperBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_HIGH, bar);
             ma3.lowerBand[bar] = iMA(NULL, NULL, ma3.periods, 0, ma3.method, PRICE_LOW,  bar);
+         }
+         if (MA3.ChannelWidth.Pct != 100) {
+            range     = ma3.upperBand[bar] - ma3.lowerBand[bar];
+            extension = (MA3.ChannelWidth.Pct - 100) / 100.0 / 2;
+            ma3.upperBand[bar] += extension * range;
+            ma3.lowerBand[bar] -= extension * range;
          }
 
          if      (Close[bar] > ma3.upperBand[bar]) ma3.position[bar] = +1;
@@ -651,27 +683,30 @@ string GetChannelDescription() {
  */
 string InputsToStr() {
    return(StringConcatenate(
-      "MA1.Method=",              DoubleQuoteStr(MA1.Method),              ";", NL,
-      "MA1.Periods=",             MA1.Periods,                             ";", NL,
-      "MA1.Color=",               ColorToStr(MA1.Color),                   ";", NL,
+      "MA1.Method=",              DoubleQuoteStr(MA1.Method),              ";"+ NL,
+      "MA1.Periods=",             MA1.Periods,                             ";"+ NL,
+      "MA1.ChannelWidth.Pct=",    MA1.ChannelWidth.Pct,                    ";"+ NL,
+      "MA1.Color=",               ColorToStr(MA1.Color),                   ";"+ NL,
 
-      "MA2.Method=",              DoubleQuoteStr(MA2.Method),              ";", NL,
-      "MA2.Periods=",             MA2.Periods,                             ";", NL,
-      "MA2.Color=",               ColorToStr(MA2.Color),                   ";", NL,
+      "MA2.Method=",              DoubleQuoteStr(MA2.Method),              ";"+ NL,
+      "MA2.Periods=",             MA2.Periods,                             ";"+ NL,
+      "MA2.ChannelWidth.Pct=",    MA2.ChannelWidth.Pct,                    ";"+ NL,
+      "MA2.Color=",               ColorToStr(MA2.Color),                   ";"+ NL,
 
-      "MA3.Method=",              DoubleQuoteStr(MA3.Method),              ";", NL,
-      "MA3.Periods=",             MA3.Periods,                             ";", NL,
-      "MA3.Color=",               ColorToStr(MA3.Color),                   ";", NL,
+      "MA3.Method=",              DoubleQuoteStr(MA3.Method),              ";"+ NL,
+      "MA3.Periods=",             MA3.Periods,                             ";"+ NL,
+      "MA3.ChannelWidth.Pct=",    MA3.ChannelWidth.Pct,                    ";"+ NL,
+      "MA3.Color=",               ColorToStr(MA3.Color),                   ";"+ NL,
 
-      "ShowChartLegend=",         BoolToStr(ShowChartLegend),              ";", NL,
-      "MaxBarsBack=",             MaxBarsBack,                             ";", NL,
+      "ShowChartLegend=",         BoolToStr(ShowChartLegend),              ";"+ NL,
+      "MaxBarsBack=",             MaxBarsBack,                             ";"+ NL,
 
-      "Signal.onBarCross=",       BoolToStr(Signal.onBarCross),            ";", NL,
-      "Signal.onBarCross.Types=", DoubleQuoteStr(Signal.onBarCross.Types), ";", NL,
-      "Signal.Sound.Up=",         DoubleQuoteStr(Signal.Sound.Up),         ";", NL,
-      "Signal.Sound.Down=",       DoubleQuoteStr(Signal.Sound.Down),       ";", NL
+      "Signal.onBarCross=",       BoolToStr(Signal.onBarCross),            ";"+ NL,
+      "Signal.onBarCross.Types=", DoubleQuoteStr(Signal.onBarCross.Types), ";"+ NL,
+      "Signal.Sound.Up=",         DoubleQuoteStr(Signal.Sound.Up),         ";"+ NL,
+      "Signal.Sound.Down=",       DoubleQuoteStr(Signal.Sound.Down),       ";"+ NL
    ));
 
    // suppress compiler warnings
-   icMaChannel(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+   icMaChannel(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }

--- a/mql40/indicators/Moving Average.mq4
+++ b/mql40/indicators/Moving Average.mq4
@@ -2,7 +2,7 @@
  * A "Moving Average" indicator with support for more MA methods and additional features.
  *
  *
- * Available averaging methods:
+ * Available Moving Average methods:
  *  • SMA  = Simple Moving Average:          equal bar weighting
  *  • LWMA = Linear Weighted Moving Average: bar weighting using a linear function
  *  • EMA  = Exponential Moving Average:     bar weighting using an exponential function

--- a/mql40/indicators/Trend Bars.mq4
+++ b/mql40/indicators/Trend Bars.mq4
@@ -247,7 +247,7 @@ bool onCommand(string cmd, string params, int keys) {
 double GetMaChannel(int mode, int bar) {
    if (maChannel.method == MODE_ALMA) {
       static int buffers[] = { 0, MaChannel.MODE_MA1_UPPER_BAND, MaChannel.MODE_MA1_LOWER_BAND };
-      return(icMaChannel(NULL, MODE_ALMA, maChannel.periods, 0, 0, 0, 0, buffers[mode], bar));
+      return(icMaChannel(NULL, MODE_ALMA, maChannel.periods, 100, 0, 0, 0, 0, 0, 0, buffers[mode], bar));
    }
    static int priceTypes[] = { 0, PRICE_HIGH, PRICE_LOW };
    return(iMA(NULL, NULL, maChannel.periods, 0, maChannel.method, priceTypes[mode], bar));

--- a/mql40/indicators/Trend Bars.mq4
+++ b/mql40/indicators/Trend Bars.mq4
@@ -246,8 +246,8 @@ bool onCommand(string cmd, string params, int keys) {
  */
 double GetMaChannel(int mode, int bar) {
    if (maChannel.method == MODE_ALMA) {
-      static int buffers[] = { 0, MaChannel.MODE_UPPER_BAND, MaChannel.MODE_LOWER_BAND };
-      return(icMaChannel(NULL, maChannel.definition, buffers[mode], bar));
+      static int buffers[] = { 0, MaChannel.MODE_MA1_UPPER_BAND, MaChannel.MODE_MA1_LOWER_BAND };
+      return(icMaChannel(NULL, MODE_ALMA, maChannel.periods, 0, 0, 0, 0, buffers[mode], bar));
    }
    static int priceTypes[] = { 0, PRICE_HIGH, PRICE_LOW };
    return(iMA(NULL, NULL, maChannel.periods, 0, maChannel.method, priceTypes[mode], bar));

--- a/mql40/indicators/Trend Bars.mq4
+++ b/mql40/indicators/Trend Bars.mq4
@@ -246,10 +246,10 @@ bool onCommand(string cmd, string params, int keys) {
  */
 double GetMaChannel(int mode, int bar) {
    if (maChannel.method == MODE_ALMA) {
-      static int buffers[] = {0, MaChannel.MODE_UPPER_BAND, MaChannel.MODE_LOWER_BAND};
+      static int buffers[] = { 0, MaChannel.MODE_UPPER_BAND, MaChannel.MODE_LOWER_BAND };
       return(icMaChannel(NULL, maChannel.definition, buffers[mode], bar));
    }
-   static int priceTypes[] = {0, PRICE_HIGH, PRICE_LOW};
+   static int priceTypes[] = { 0, PRICE_HIGH, PRICE_LOW };
    return(iMA(NULL, NULL, maChannel.periods, 0, maChannel.method, priceTypes[mode], bar));
 }
 

--- a/templates4/23  LWMA(55) Channel.tpl
+++ b/templates4/23  LWMA(55) Channel.tpl
@@ -169,7 +169,8 @@ name=MA Channel
 flags=339
 window_num=0
 <inputs>
-Channel.Definition=LWMA(55)
+MA1.Method=LWMA
+MA1.Periods=55
 ShowChartLegend=1
 AutoConfiguration=0
 </inputs>

--- a/templates4/23  LWMA(55) Channel.tpl
+++ b/templates4/23  LWMA(55) Channel.tpl
@@ -172,7 +172,6 @@ window_num=0
 MA1.Method=LWMA
 MA1.Periods=55
 ShowChartLegend=1
-AutoConfiguration=0
 </inputs>
 </expert>
 show_data=1


### PR DESCRIPTION
- fixed channel logic
- updated indicator inputs: each MA/channel is configured separately
- limited the indicator to 1-3 separate channels
- support for moving average method "ALMA"
- option to increase/decrease the width of each MA channel (input "MA.ChannelWidth.Pct")
- separate buffers for channel position and channel trend
- separate signaling options for channel position and channel trend

@codex review